### PR TITLE
Added AttributeTargetName to map source to destination columns

### DIFF
--- a/src/azure.datafactory/pipeline/Ingest_PL_MSSQL.json
+++ b/src/azure.datafactory/pipeline/Ingest_PL_MSSQL.json
@@ -265,7 +265,11 @@
 												"type": "ParquetWriteSettings"
 											}
 										},
-										"enableStaging": false
+										"enableStaging": false,
+										"translator": {
+											"value": "@json(activity('Get Ingest Payload').output.firstRow.SourceDestMapping)",
+											"type": "Expression"
+										}
 									},
 									"inputs": [
 										{
@@ -431,12 +435,8 @@
 										},
 										"enableStaging": false,
 										"translator": {
-											"type": "TabularTranslator",
-											"typeConversion": true,
-											"typeConversionSettings": {
-												"allowDataTruncation": true,
-												"treatBooleanAsNumber": false
-											}
+											"value": "@json(activity('Get Ingest Payload').output.firstRow.SourceDestMapping)",
+											"type": "Expression"
 										}
 									},
 									"inputs": [
@@ -603,12 +603,8 @@
 										},
 										"enableStaging": false,
 										"translator": {
-											"type": "TabularTranslator",
-											"typeConversion": true,
-											"typeConversionSettings": {
-												"allowDataTruncation": true,
-												"treatBooleanAsNumber": false
-											}
+											"value": "@json(activity('Get Ingest Payload').output.firstRow.SourceDestMapping)",
+											"type": "Expression"
 										}
 									},
 									"inputs": [

--- a/src/metadata.ingest/ingest/Tables/Attributes.sql
+++ b/src/metadata.ingest/ingest/Tables/Attributes.sql
@@ -3,6 +3,7 @@ CREATE TABLE [ingest].[Attributes](
 	[DatasetFK] [int] NULL,
 	[AttributeName] [nvarchar](50) NOT NULL,
 	[AttributeSourceDataType] [nvarchar](50) NULL,
+	[AttributeTargetName] [nvarchar](50) NULL,
 	[AttributeTargetDataType] [nvarchar](50) NULL,
 	[AttributeTargetDataFormat] [varchar](100) NULL,
 	[AttributeDescription] [nvarchar](200) NULL,


### PR DESCRIPTION
This pull request introduces the following enhancements to address the issue while maintaining backward compatibility:

**Metadata Table Enhancement:**
Added a new column, AttributeTargetName, to the [ingest].[Attributes] metadata table. This column allows users to specify a Parquet-compatible column name for each source column.

**Default Behavior:**
If AttributeTargetName is left blank or NULL, the system defaults to using the original source column name (AttributeName), ensuring no disruption to existing workflows.

**Stored Procedure Update:**
Modified the [ingest].[GetDatasetPayload] stored procedure to include AttributeTargetName in the TabularTranslator JSON expression. If AttributeTargetName is not specified, the JSON references AttributeName, ensuring consistent behaviour for columns without custom mappings.

The changes are non-breaking, and existing pipelines will continue to function without requiring updates unless explicitly configured to use the new feature. #122 