### PR TITLE
Add defensive checks for input parameters in stored procedures

### DIFF
--- a/src/metadata.ingest/ingest/Stored Procedures/GetDatasetPayload.sql
+++ b/src/metadata.ingest/ingest/Stored Procedures/GetDatasetPayload.sql
@@ -353,7 +353,7 @@ BEGIN
  
 	ELSE IF (@LoadType = 'I') AND (@ConnectionType = 'Files')
     BEGIN
-        RAISERROR('The Files Connection type does not support incremental loading. Please change the load type in Ingest.datasets.',16,1)
+        RAISERROR('The Files Connection type does not support incremental loading. Please change the load type in ingest.Datasets.',16,1)
         RETURN 0;
     END
 

--- a/src/metadata.ingest/ingest/Stored Procedures/GetDatasetPayload.sql
+++ b/src/metadata.ingest/ingest/Stored Procedures/GetDatasetPayload.sql
@@ -350,6 +350,12 @@ BEGIN
         SET @SourceQuery = @SourceQuery
         SET @LoadAction = 'incremental'
     END
+ 
+	ELSE IF (@LoadType = 'I') AND (@ConnectionType = 'Files')
+    BEGIN
+        RAISERROR('The Files Connection type does not support incremental loading. Please change the load type in Ingest.datasets.',16,1)
+        RETURN 0;
+    END
 
     ELSE IF (@LoadType = 'I') AND (@SourceLanguageType <> 'XML') AND (@ConnectionType <> 'REST API')
     BEGIN

--- a/src/metadata.ingest/ingest/Stored Procedures/SetIngestLoadStatus.sql
+++ b/src/metadata.ingest/ingest/Stored Procedures/SetIngestLoadStatus.sql
@@ -32,13 +32,13 @@ END
 
 IF @LoadType NOT IN ('F', 'I')
 BEGIN
-    RAISERROR('Load Type specified not supported. Please specify either I or F',16,1)
+    RAISERROR('Load Type specified not supported. Please specify either ''I'' or ''F''',16,1)
 	RETURN 0;
 END
 
 IF @IngestStage NOT IN ('Raw','Cleansed')
 BEGIN
-    RAISERROR('Ingest Stage specified not supported. Please specify either Raw or Cleansed',16,1)
+    RAISERROR('Ingest Stage specified not supported. Please specify either ''Raw'' or ''Cleansed''',16,1)
     RETURN 0;
 END
 

--- a/src/metadata.ingest/ingest/Stored Procedures/SetIngestLoadStatus.sql
+++ b/src/metadata.ingest/ingest/Stored Procedures/SetIngestLoadStatus.sql
@@ -27,7 +27,7 @@ AND
 IF @ResultRowCount = 0
 BEGIN
     RAISERROR('No results returned for the provided Dataset Id. Confirm Dataset is enabled, and related Connections are enabled.',16,1)
-    RETURN 0;
+	RETURN 0;
 END
 
 IF @LoadType NOT IN ('F', 'I')
@@ -39,7 +39,7 @@ END
 IF @IngestStage NOT IN ('Raw','Cleansed')
 BEGIN
     RAISERROR('Ingest Stage specified not supported. Please specify either ''Raw'' or ''Cleansed''',16,1)
-    RETURN 0;
+	RETURN 0;
 END
 
 DECLARE @LoadStatus INT

--- a/src/metadata.ingest/ingest/Stored Procedures/SetIngestLoadStatus.sql
+++ b/src/metadata.ingest/ingest/Stored Procedures/SetIngestLoadStatus.sql
@@ -7,6 +7,41 @@ CREATE PROCEDURE [ingest].[SetIngestLoadStatus]
 )
 AS
 BEGIN
+
+-- Defensive checks for input parameters
+DECLARE @ResultRowCount INT
+
+SELECT 
+    @ResultRowCount = COUNT(*)
+FROM
+[ingest].[Datasets] ds
+INNER JOIN [common].[Connections] cn
+    ON ds.[ConnectionFK] = cn.[ConnectionId]
+WHERE
+ds.[DatasetId] = @DatasetId
+AND 
+    ds.[Enabled] = 1
+AND 
+    cn.[Enabled] = 1
+
+IF @ResultRowCount = 0
+BEGIN
+    RAISERROR('No results returned for the provided Dataset Id. Confirm Dataset is enabled, and related Connections are enabled.',16,1)
+    RETURN 0;
+END
+
+IF @LoadType NOT IN ('F', 'I')
+BEGIN
+    RAISERROR('Load Type specified not supported. Please specify either I or F',16,1)
+	RETURN 0;
+END
+
+IF @IngestStage NOT IN ('Raw','Cleansed')
+BEGIN
+    RAISERROR('Ingest Stage specified not supported. Please specify either Raw or Cleansed',16,1)
+    RETURN 0;
+END
+
 DECLARE @LoadStatus INT
 
 SELECT 

--- a/src/metadata.transform/transform/Stored Procedures/SetTransformLoadStatus.sql
+++ b/src/metadata.transform/transform/Stored Procedures/SetTransformLoadStatus.sql
@@ -25,7 +25,7 @@ AND
 IF @ResultRowCount = 0
 BEGIN
     RAISERROR('No results returned for the provided Dataset Id. Confirm Dataset is enabled, and related Connections are enabled.',16,1)
-RETURN 0;
+	RETURN 0;
 END
 
 UPDATE [transform].[Datasets]

--- a/src/metadata.transform/transform/Stored Procedures/SetTransformLoadStatus.sql
+++ b/src/metadata.transform/transform/Stored Procedures/SetTransformLoadStatus.sql
@@ -6,6 +6,28 @@ CREATE PROCEDURE [transform].[SetTransformLoadStatus]
 AS
 BEGIN
 
+-- Defensive check for DatasetId parameter
+DECLARE @ResultRowCount INT
+
+SELECT 
+    @ResultRowCount = COUNT(*)
+FROM
+[ingest].[Datasets] ds
+INNER JOIN [common].[Connections] cn
+    ON ds.[ConnectionFK] = cn.[ConnectionId]
+WHERE
+ds.[DatasetId] = @DatasetId
+AND 
+    ds.[Enabled] = 1
+AND 
+    cn.[Enabled] = 1
+
+IF @ResultRowCount = 0
+BEGIN
+    RAISERROR('No results returned for the provided Dataset Id. Confirm Dataset is enabled, and related Connections are enabled.',16,1)
+RETURN 0;
+END
+
 UPDATE [transform].[Datasets]
 SET LoadStatus = 1,
     LastLoadDate = @FileLoadDateTime


### PR DESCRIPTION
Created the defensive checks for the input parameters of tranform.SetTransformLoadStatus and ingest.SetIngestLoadStatus and added a check that throws an error when attempting to perform an incremental load when ingesting from a file store.