### PR TITLE
Adding Stored procs and MetadataAsCode scripts

### DIFF
--- a/src/metadata.common/Scripts/MetadataAsCodeCommon.sql
+++ b/src/metadata.common/Scripts/MetadataAsCodeCommon.sql
@@ -1,13 +1,14 @@
 -- Metadata As Code - Common - add connections and compute connections
 
 --Connections - Azure services:
-EXEC ##AddConnections 'Azure Data Lake Gen2', 'PrimaryDataLake', '$(DLS)', NULL, 'raw', 'NA', 'Ingest_LS_DataLake_MIAuth', '$(DLSRawKey)', 'NA', 1;
-EXEC ##AddConnections 'Azure Data Lake Gen2', 'PrimaryDataLake', '$(DLS)', NULL, 'cleansed', 'NA', 'Ingest_LS_DataLake_MIAuth', '$(DLSCleansedKey)', 'NA', 1;
+EXEC ##AddConnections 'Azure Data Lake Gen2', 'PrimaryDataLake', '$(DLSName)', NULL, 'raw', 'NA', 'Ingest_LS_DataLake_MIAuth', '$(DLSName)rawaccesskey', 'NA', 1;
+EXEC ##AddConnections 'Azure Data Lake Gen2', 'PrimaryDataLake', '$(DLSName)', NULL, 'cleansed', 'NA', 'Ingest_LS_DataLake_MIAuth', '$(DLSName)cleansedaccesskey', 'NA', 1;
+EXEC ##AddConnections 'Azure Data Lake Gen2', 'PrimaryDataLake', '$(DLSName)', NULL, 'curated', 'NA', 'Ingest_LS_DataLake_MIAuth', '$(DLSName)curatedaccesskey', 'NA', 1;
 EXEC ##AddConnections 'Azure Key Vault', 'PrimaryKeyVault', 'https://$(KeyVaultName).vault.azure.net/', NULL, '$(KeyVaultName)', '$(KeyVaultName)', 'Common_LS_cumuluskeys', 'NA', 'NA', 1;
-EXEC ##AddConnections 'Azure Resource Group', 'PrimaryResourceGroup', NULL, NULL, '$(RG)', '$(RG)', 'NA', 'NA', 'NA', 1;
-EXEC ##AddConnections 'Azure Subscription', 'PrimarySubscription', NULL, NULL, '$(SubID)', '$(SubID)', 'NA', 'NA', 'NA', 1;
-EXEC ##AddConnections 'Azure SQL Database', 'AdventureWorksDemo', '$(DemoConnLocation)', NULL, '$(DemoSourceLocation)', '$(DemoResourceName)', '$(DemoLinkedServ)', '$(DemoUsername)', '$(DemoKVSecret)', 1;
+EXEC ##AddConnections 'Azure Resource Group', 'PrimaryResourceGroup', NULL, NULL, '$(RGName)', '$(RGName)', 'NA', 'NA', 'NA', 1;
+EXEC ##AddConnections 'Azure Subscription', 'PrimarySubscription', NULL, NULL, '$(SubscriptionID)', '$(SubscriptionID)', 'NA', 'NA', 'NA', 1;
+EXEC ##AddConnections 'Azure SQL Database', 'AdventureWorksDemo', '$(DemoConnectionLocation)', NULL, '$(DemoSourceLocation)', '$(DemoResourceName)', '$(DemoLinkedService)', '$(DemoUsername)', '$(DemoKVSecret)', 1;
 
 --ComputeConnections
-EXEC ##AddComputeConnections 'Azure Databricks', 'CF.Cumulus.Ingest.Compute', '$(DBURL)', '$(IngestCompute)', 'Standard_D4ds_v5', '15.4.x-scala2.12', 1, '$(DBName)', 'Ingest_LS_Databricks_Cluster_MIAuth', 'Dev', 1;
-EXEC ##AddComputeConnections 'Azure Databricks', 'CF.Cumulus.Transform.Compute', '$(DBURL)', '$(TransformCompute)', 'Standard_E8_v3', '15.4.x-scala2.12', 2, '$(DBName)', 'Ingest_LS_Databricks_JobCluster_MIAuth', 'Dev', 1;
+EXEC ##AddComputeConnections 'Azure Databricks', 'CF.Cumulus.Ingest.Compute', '$(DatabricksWSURL)', '', 'Standard_D4ds_v5', '15.4.x-scala2.12', 1, '$(DatabricksWSName)', 'Ingest_LS_Databricks_Cluster_MIAuth', '$(EnvironmentName)', 1;
+EXEC ##AddComputeConnections 'Azure Databricks', 'CF.Cumulus.Transform.Compute', '$(DatabricksWSURL)', '', 'Standard_E8_v3', '15.4.x-scala2.12', 2, '$(DatabricksWSName)', 'Ingest_LS_Databricks_JobCluster_MIAuth', '$(EnvironmentName)', 1;

--- a/src/metadata.common/Scripts/MetadataAsCodeCommon.sql
+++ b/src/metadata.common/Scripts/MetadataAsCodeCommon.sql
@@ -1,0 +1,13 @@
+-- Metadata As Code - Common - add connections and compute connections
+
+--Connections - Azure services:
+EXEC ##AddConnections 'Azure Data Lake Gen2', 'PrimaryDataLake', '$(DLS)', NULL, 'raw', 'NA', 'Ingest_LS_DataLake_MIAuth', '$(DLSRawKey)', 'NA', 1;
+EXEC ##AddConnections 'Azure Data Lake Gen2', 'PrimaryDataLake', '$(DLS)', NULL, 'cleansed', 'NA', 'Ingest_LS_DataLake_MIAuth', '$(DLSCleansedKey)', 'NA', 1;
+EXEC ##AddConnections 'Azure Key Vault', 'PrimaryKeyVault', 'https://$(KeyVaultName).vault.azure.net/', NULL, '$(KeyVaultName)', '$(KeyVaultName)', 'Common_LS_cumuluskeys', 'NA', 'NA', 1;
+EXEC ##AddConnections 'Azure Resource Group', 'PrimaryResourceGroup', NULL, NULL, '$(RG)', '$(RG)', 'NA', 'NA', 'NA', 1;
+EXEC ##AddConnections 'Azure Subscription', 'PrimarySubscription', NULL, NULL, '$(SubID)', '$(SubID)', 'NA', 'NA', 'NA', 1;
+EXEC ##AddConnections 'Azure SQL Database', 'AdventureWorksDemo', '$(DemoConnLocation)', NULL, '$(DemoSourceLocation)', '$(DemoResourceName)', '$(DemoLinkedServ)', '$(DemoUsername)', '$(DemoKVSecret)', 1;
+
+--ComputeConnections
+EXEC ##AddComputeConnections 'Azure Databricks', 'CF.Cumulus.Ingest.Compute', '$(DBURL)', '$(IngestCompute)', 'Standard_D4ds_v5', '15.4.x-scala2.12', 1, '$(DBName)', 'Ingest_LS_Databricks_Cluster_MIAuth', 'Dev', 1;
+EXEC ##AddComputeConnections 'Azure Databricks', 'CF.Cumulus.Transform.Compute', '$(DBURL)', '$(TransformCompute)', 'Standard_E8_v3', '15.4.x-scala2.12', 2, '$(DBName)', 'Ingest_LS_Databricks_JobCluster_MIAuth', 'Dev', 1;

--- a/src/metadata.common/Scripts/MetadataAsCodeCommon.sql
+++ b/src/metadata.common/Scripts/MetadataAsCodeCommon.sql
@@ -5,8 +5,8 @@ EXEC ##AddConnections 'Azure Data Lake Gen2', 'PrimaryDataLake', '$(DLSName)', N
 EXEC ##AddConnections 'Azure Data Lake Gen2', 'PrimaryDataLake', '$(DLSName)', NULL, 'cleansed', 'NA', 'Ingest_LS_DataLake_MIAuth', '$(DLSName)cleansedaccesskey', 'NA', 1;
 EXEC ##AddConnections 'Azure Data Lake Gen2', 'PrimaryDataLake', '$(DLSName)', NULL, 'curated', 'NA', 'Ingest_LS_DataLake_MIAuth', '$(DLSName)curatedaccesskey', 'NA', 1;
 EXEC ##AddConnections 'Azure Key Vault', 'PrimaryKeyVault', 'https://$(KeyVaultName).vault.azure.net/', NULL, '$(KeyVaultName)', '$(KeyVaultName)', 'Common_LS_cumuluskeys', 'NA', 'NA', 1;
-EXEC ##AddConnections 'Azure Resource Group', 'PrimaryResourceGroup', NULL, NULL, '$(RGName)', '$(RGName)', 'NA', 'NA', 'NA', 1;
-EXEC ##AddConnections 'Azure Subscription', 'PrimarySubscription', NULL, NULL, '$(SubscriptionID)', '$(SubscriptionID)', 'NA', 'NA', 'NA', 1;
+EXEC ##AddConnections 'Azure Resource Group', 'PrimaryResourceGroup', 'NA', NULL, '$(RGName)', '$(RGName)', 'NA', 'NA', 'NA', 1;
+EXEC ##AddConnections 'Azure Subscription', 'PrimarySubscription', 'NA', NULL, '$(SubscriptionID)', '$(SubscriptionID)', 'NA', 'NA', 'NA', 1;
 EXEC ##AddConnections 'Azure SQL Database', 'AdventureWorksDemo', '$(DemoConnectionLocation)', NULL, '$(DemoSourceLocation)', '$(DemoResourceName)', '$(DemoLinkedService)', '$(DemoUsername)', '$(DemoKVSecret)', 1;
 
 --ComputeConnections

--- a/src/metadata.common/Scripts/Script.PostDeployment.sql
+++ b/src/metadata.common/Scripts/Script.PostDeployment.sql
@@ -11,4 +11,5 @@ Post-Deployment Script Template
 */
 --load default metadata
 :r .\DefaultConnectionTypes.sql
+:r .\MetadataAsCodeCommon.sql
 

--- a/src/metadata.common/common/Stored Procedures/AddComputeConnections.sql
+++ b/src/metadata.common/common/Stored Procedures/AddComputeConnections.sql
@@ -1,0 +1,71 @@
+CREATE PROCEDURE ##AddComputeConnections
+(
+	@ConnectionTypeDisplayName NVARCHAR(50),
+	@ConnectionDisplayName NVARCHAR(50),
+	@ConnectionLocation NVARCHAR(200),
+	@ComputeLocation NVARCHAR(200),
+	@ComputeSize NVARCHAR(200),
+	@ComputeVersion NVARCHAR(100),
+	@CountNodes INT,
+	@ResourceName NVARCHAR(100),
+	@LinkedServiceName NVARCHAR(200),
+	@EnvironmentName NVARCHAR(10),
+	@Enabled BIT
+
+)
+AS
+BEGIN
+	SET NOCOUNT ON;
+	DECLARE @ComputeConnections TABLE (
+		ConnectionTypeFK INT NOT NULL,
+		ConnectionTypeDisplayName NVARCHAR(50),
+		ConnectionDisplayName NVARCHAR(50) NOT NULL,
+		ConnectionLocation NVARCHAR(200),
+		ComputeLocation NVARCHAR(200),
+		ComputeSize NVARCHAR(200) NOT NULL,
+		ComputeVersion NVARCHAR(100) NOT NULL,
+		CountNodes INT NOT NULL,
+		ResourceName NVARCHAR(100),
+		LinkedServiceName NVARCHAR(200) NOT NULL,
+		EnvironmentName NVARCHAR(10),
+		Enabled BIT NOT NULL
+	)
+
+	INSERT INTO @ComputeConnections(ConnectionTypeFK, ConnectionTypeDisplayName, ConnectionDisplayName, ConnectionLocation, ComputeLocation, ComputeSize, ComputeVersion, CountNodes, ResourceName, LinkedServiceName, EnvironmentName, Enabled)
+	VALUES (-1, @ConnectionTypeDisplayName, @ConnectionDisplayName, @ConnectionLocation, @ComputeLocation, @ComputeSize, @ComputeVersion, @CountNodes, @ResourceName, @LinkedServiceName, @EnvironmentName, @Enabled)
+
+	UPDATE c
+	SET c.ConnectionTypeFK = ct.ConnectionTypeId
+	FROM @ComputeConnections AS c
+	INNER JOIN common.ConnectionTypes AS ct
+	ON ct.ConnectionTypeDisplayName = c.ConnectionTypeDisplayName
+
+	IF (SELECT ConnectionTypeFK FROM @ComputeConnections) = -1
+	BEGIN
+		RAISERROR('ConnectionTypeFK not updated as the ConnectionTypeDisplayName does not exist within common.ConnectionTypes.',16,1)
+		RETURN 0;
+	END
+
+
+	MERGE INTO common.ComputeConnections AS Target
+	USING @ComputeConnections AS Source
+	ON Source.ConnectionDisplayName = Target.ConnectionDisplayName
+	AND Source.ConnectionLocation = Target.ConnectionLocation
+	AND Source.ComputeLocation = Target.ComputeLocation
+
+	WHEN NOT MATCHED THEN
+		INSERT (ConnectionTypeFK, ConnectionDisplayName, ConnectionLocation, ComputeLocation, ComputeSize, ComputeVersion, CountNodes, ResourceName, LinkedServiceName, EnvironmentName, Enabled)
+		VALUES (Source.ConnectionTypeFK, Source.ConnectionDisplayName, Source.ConnectionLocation, Source.ComputeLocation, Source.ComputeSize, Source.ComputeVersion, Source.CountNodes, Source.ResourceName, Source.LinkedServiceName, Source.EnvironmentName, Source.Enabled)
+
+	WHEN MATCHED THEN UPDATE SET
+		Target.ConnectionTypeFK = Source.ConnectionTypeFK,
+		Target.ComputeSize = Source.ComputeSize,
+		Target.ComputeVersion = Source.ComputeVersion,
+		Target.CountNodes = Source.CountNodes,
+		Target.ResourceName = Source.ResourceName,
+		Target.LinkedServiceName = Source.LinkedServiceName,
+		Target.EnvironmentName = Source.EnvironmentName,
+		Target.Enabled = Source.Enabled
+	;
+END
+GO

--- a/src/metadata.common/common/Stored Procedures/AddComputeConnections.sql
+++ b/src/metadata.common/common/Stored Procedures/AddComputeConnections.sql
@@ -51,7 +51,6 @@ BEGIN
 	USING @ComputeConnections AS Source
 	ON Source.ConnectionDisplayName = Target.ConnectionDisplayName
 	AND Source.ConnectionLocation = Target.ConnectionLocation
-	AND Source.ComputeLocation = Target.ComputeLocation
 
 	WHEN NOT MATCHED THEN
 		INSERT (ConnectionTypeFK, ConnectionDisplayName, ConnectionLocation, ComputeLocation, ComputeSize, ComputeVersion, CountNodes, ResourceName, LinkedServiceName, EnvironmentName, Enabled)
@@ -59,6 +58,7 @@ BEGIN
 
 	WHEN MATCHED THEN UPDATE SET
 		Target.ConnectionTypeFK = Source.ConnectionTypeFK,
+		Target.ComputeLocation = Source.ComputeLocation,
 		Target.ComputeSize = Source.ComputeSize,
 		Target.ComputeVersion = Source.ComputeVersion,
 		Target.CountNodes = Source.CountNodes,

--- a/src/metadata.common/common/Stored Procedures/AddConnections.sql
+++ b/src/metadata.common/common/Stored Procedures/AddConnections.sql
@@ -1,0 +1,67 @@
+CREATE PROCEDURE ##AddConnections
+(
+	@ConnectionTypeDisplayName NVARCHAR(50),
+	@ConnectionDisplayName NVARCHAR(50),
+	@ConnectionLocation NVARCHAR(200),
+	@ConnectionPort NVARCHAR(50),
+	@SourceLocation NVARCHAR(200),
+	@ResourceName NVARCHAR(100),
+	@LinkedServiceName NVARCHAR(200),
+	@Username NVARCHAR(150),
+	@KeyVaultSecret NVARCHAR(150),
+	@Enabled BIT
+
+)
+AS
+BEGIN
+	SET NOCOUNT ON;
+	DECLARE @Connections TABLE (
+		ConnectionTypeFK INT NOT NULL,
+		ConnectionTypeDisplayName NVARCHAR(50) NOT NULL,
+		ConnectionDisplayName NVARCHAR(50) NOT NULL,
+		ConnectionLocation NVARCHAR(200),
+		ConnectionPort NVARCHAR(50),
+		SourceLocation NVARCHAR(200) NOT NULL,
+		ResourceName NVARCHAR(100),
+		LinkedServiceName NVARCHAR(200) NOT NULL,
+		Username NVARCHAR(150) NOT NULL,
+		KeyVaultSecret NVARCHAR(150) NOT NULL,
+		Enabled BIT NOT NULL
+	)
+
+	INSERT INTO @Connections(ConnectionTypeFK, ConnectiontypeDisplayName, ConnectionDisplayName, ConnectionLocation, ConnectionPort, SourceLocation, ResourceName, LinkedServiceName, Username, KeyVaultSecret, Enabled)
+	VALUES (-1, @ConnectionTypeDisplayName, @ConnectionDisplayName, @ConnectionLocation, @ConnectionPort, @SourceLocation, @ResourceName, @LinkedServiceName, @Username, @KeyVaultSecret, @Enabled)
+
+	UPDATE c
+	SET c.ConnectionTypeFK = ct.ConnectionTypeId
+	FROM @Connections AS c
+	INNER JOIN common.ConnectionTypes AS ct
+	ON ct.ConnectionTypeDisplayName = c.ConnectionTypeDisplayName
+
+	IF (SELECT ConnectionTypeFK FROM @Connections) = -1
+	BEGIN
+		RAISERROR('ConnectionTypeFK not updated as the ConnectionTypeDisplayName does not exist within common.ConnectionTypes.',16,1)
+		RETURN 0;
+	END
+ 
+	MERGE INTO common.Connections AS Target
+	USING @Connections AS Source
+	ON Source.ConnectionDisplayName = Target.ConnectionDisplayName
+	AND Source.ConnectionLocation = Target.ConnectionLocation
+	AND Source.SourceLocation = Target.SourceLocation
+
+	WHEN NOT MATCHED THEN
+		INSERT (ConnectionTypeFK, ConnectionDisplayName, ConnectionLocation, ConnectionPort, SourceLocation, ResourceName, LinkedServiceName, Username, KeyVaultSecret, Enabled)
+		VALUES (Source.ConnectionTypeFK, Source.ConnectionDisplayName, Source.ConnectionLocation, Source.ConnectionPort, Source.SourceLocation, Source.ResourceName, Source.LinkedServiceName, Source.Username, Source.KeyVaultSecret, Source.Enabled)
+
+	WHEN MATCHED THEN UPDATE SET
+		Target.ConnectionTypeFK = Source.ConnectionTypeFK,
+		Target.ConnectionPort = Source.ConnectionPort,
+		Target.ResourceName = Source.ResourceName,
+		Target.LinkedServiceName = Source.LinkedServiceName,
+		Target.Username = Source.Username,
+		Target.KeyVaultSecret = Source.KeyVaultSecret,
+		Target.Enabled = Source.Enabled
+	;
+END
+GO

--- a/src/metadata.common/common/Stored Procedures/AddConnections.sql
+++ b/src/metadata.common/common/Stored Procedures/AddConnections.sql
@@ -43,11 +43,12 @@ BEGIN
 		RAISERROR('ConnectionTypeFK not updated as the ConnectionTypeDisplayName does not exist within common.ConnectionTypes.',16,1)
 		RETURN 0;
 	END
- 
+
 	MERGE INTO common.Connections AS Target
 	USING @Connections AS Source
 	ON Source.ConnectionDisplayName = Target.ConnectionDisplayName
 	AND Source.ConnectionLocation = Target.ConnectionLocation
+	AND Source.LinkedServiceName = Target.LinkedServiceName
 	AND Source.SourceLocation = Target.SourceLocation
 
 	WHEN NOT MATCHED THEN
@@ -58,7 +59,6 @@ BEGIN
 		Target.ConnectionTypeFK = Source.ConnectionTypeFK,
 		Target.ConnectionPort = Source.ConnectionPort,
 		Target.ResourceName = Source.ResourceName,
-		Target.LinkedServiceName = Source.LinkedServiceName,
 		Target.Username = Source.Username,
 		Target.KeyVaultSecret = Source.KeyVaultSecret,
 		Target.Enabled = Source.Enabled

--- a/src/metadata.common/metadata.common.sqlproj
+++ b/src/metadata.common/metadata.common.sqlproj
@@ -66,16 +66,101 @@
   </ItemGroup>
   <ItemGroup>
     <Build Include="common\Stored Procedures\AddConnectionType.sql" />
+    <Build Include="common\Stored Procedures\AddComputeConnections.sql" />
+    <Build Include="common\Stored Procedures\AddConnections.sql" />
     <Build Include="common\Tables\ComputeConnections.sql" />
     <Build Include="common\Tables\Connections.sql" />
     <Build Include="common\Tables\ConnectionTypes.sql" />
     <Build Include="Security\common.sql" />
     <None Include="Scripts\DefaultConnectionTypes.sql" />
+    <None Include="Scripts\MetadataAsCodeCommon.sql" />
   </ItemGroup>
   <ItemGroup>
     <PostDeploy Include="Scripts\Script.PostDeployment.sql" />
   </ItemGroup>
   <ItemGroup>
     <PreDeploy Include="Scripts\Script.PreDeployment.sql" />
+  </ItemGroup>
+  <ItemGroup>
+    <SqlCmdVariable Include="DBName">
+      <DefaultValue>
+      </DefaultValue>
+      <Value>$(SqlCmdVar__14)</Value>
+    </SqlCmdVariable>
+    <SqlCmdVariable Include="DBURL">
+      <DefaultValue>
+      </DefaultValue>
+      <Value>$(SqlCmdVar__13)</Value>
+    </SqlCmdVariable>
+    <SqlCmdVariable Include="DemoConnLocation">
+      <DefaultValue>
+      </DefaultValue>
+      <Value>$(SqlCmdVar__7)</Value>
+    </SqlCmdVariable>
+    <SqlCmdVariable Include="DemoKVSecret">
+      <DefaultValue>
+      </DefaultValue>
+      <Value>$(SqlCmdVar__12)</Value>
+    </SqlCmdVariable>
+    <SqlCmdVariable Include="DemoLinkedServ">
+      <DefaultValue>
+      </DefaultValue>
+      <Value>$(SqlCmdVar__10)</Value>
+    </SqlCmdVariable>
+    <SqlCmdVariable Include="DemoResourceName">
+      <DefaultValue>
+      </DefaultValue>
+      <Value>$(SqlCmdVar__9)</Value>
+    </SqlCmdVariable>
+    <SqlCmdVariable Include="DemoSourceLocation">
+      <DefaultValue>
+      </DefaultValue>
+      <Value>$(SqlCmdVar__8)</Value>
+    </SqlCmdVariable>
+    <SqlCmdVariable Include="DemoUsername">
+      <DefaultValue>
+      </DefaultValue>
+      <Value>$(SqlCmdVar__11)</Value>
+    </SqlCmdVariable>
+    <SqlCmdVariable Include="DLS">
+      <DefaultValue>
+      </DefaultValue>
+      <Value>$(SqlCmdVar__1)</Value>
+    </SqlCmdVariable>
+    <SqlCmdVariable Include="DLSCleansedKey">
+      <DefaultValue>
+      </DefaultValue>
+      <Value>$(SqlCmdVar__3)</Value>
+    </SqlCmdVariable>
+    <SqlCmdVariable Include="DLSRawKey">
+      <DefaultValue>
+      </DefaultValue>
+      <Value>$(SqlCmdVar__2)</Value>
+    </SqlCmdVariable>
+    <SqlCmdVariable Include="IngestCompute">
+      <DefaultValue>
+      </DefaultValue>
+      <Value>$(SqlCmdVar__15)</Value>
+    </SqlCmdVariable>
+    <SqlCmdVariable Include="KeyVaultName">
+      <DefaultValue>
+      </DefaultValue>
+      <Value>$(SqlCmdVar__4)</Value>
+    </SqlCmdVariable>
+    <SqlCmdVariable Include="RG">
+      <DefaultValue>
+      </DefaultValue>
+      <Value>$(SqlCmdVar__5)</Value>
+    </SqlCmdVariable>
+    <SqlCmdVariable Include="SubID">
+      <DefaultValue>
+      </DefaultValue>
+      <Value>$(SqlCmdVar__6)</Value>
+    </SqlCmdVariable>
+    <SqlCmdVariable Include="TransformCompute">
+      <DefaultValue>
+      </DefaultValue>
+      <Value>$(SqlCmdVar__16)</Value>
+    </SqlCmdVariable>
   </ItemGroup>
 </Project>

--- a/src/metadata.common/metadata.common.sqlproj
+++ b/src/metadata.common/metadata.common.sqlproj
@@ -82,17 +82,17 @@
     <PreDeploy Include="Scripts\Script.PreDeployment.sql" />
   </ItemGroup>
   <ItemGroup>
-    <SqlCmdVariable Include="DBName">
+    <SqlCmdVariable Include="DatabricksWSName">
       <DefaultValue>
       </DefaultValue>
       <Value>$(SqlCmdVar__14)</Value>
     </SqlCmdVariable>
-    <SqlCmdVariable Include="DBURL">
+    <SqlCmdVariable Include="DatabricksWSURL">
       <DefaultValue>
       </DefaultValue>
       <Value>$(SqlCmdVar__13)</Value>
     </SqlCmdVariable>
-    <SqlCmdVariable Include="DemoConnLocation">
+    <SqlCmdVariable Include="DemoConnectionLocation">
       <DefaultValue>
       </DefaultValue>
       <Value>$(SqlCmdVar__7)</Value>
@@ -102,7 +102,7 @@
       </DefaultValue>
       <Value>$(SqlCmdVar__12)</Value>
     </SqlCmdVariable>
-    <SqlCmdVariable Include="DemoLinkedServ">
+    <SqlCmdVariable Include="DemoLinkedService">
       <DefaultValue>
       </DefaultValue>
       <Value>$(SqlCmdVar__10)</Value>
@@ -122,22 +122,12 @@
       </DefaultValue>
       <Value>$(SqlCmdVar__11)</Value>
     </SqlCmdVariable>
-    <SqlCmdVariable Include="DLS">
+    <SqlCmdVariable Include="DLSName">
       <DefaultValue>
       </DefaultValue>
       <Value>$(SqlCmdVar__1)</Value>
     </SqlCmdVariable>
-    <SqlCmdVariable Include="DLSCleansedKey">
-      <DefaultValue>
-      </DefaultValue>
-      <Value>$(SqlCmdVar__3)</Value>
-    </SqlCmdVariable>
-    <SqlCmdVariable Include="DLSRawKey">
-      <DefaultValue>
-      </DefaultValue>
-      <Value>$(SqlCmdVar__2)</Value>
-    </SqlCmdVariable>
-    <SqlCmdVariable Include="IngestCompute">
+    <SqlCmdVariable Include="EnvironmentName">
       <DefaultValue>
       </DefaultValue>
       <Value>$(SqlCmdVar__15)</Value>
@@ -147,20 +137,15 @@
       </DefaultValue>
       <Value>$(SqlCmdVar__4)</Value>
     </SqlCmdVariable>
-    <SqlCmdVariable Include="RG">
+    <SqlCmdVariable Include="RGName">
       <DefaultValue>
       </DefaultValue>
       <Value>$(SqlCmdVar__5)</Value>
     </SqlCmdVariable>
-    <SqlCmdVariable Include="SubID">
+    <SqlCmdVariable Include="SubscriptionID">
       <DefaultValue>
       </DefaultValue>
       <Value>$(SqlCmdVar__6)</Value>
-    </SqlCmdVariable>
-    <SqlCmdVariable Include="TransformCompute">
-      <DefaultValue>
-      </DefaultValue>
-      <Value>$(SqlCmdVar__16)</Value>
     </SqlCmdVariable>
   </ItemGroup>
 </Project>

--- a/src/metadata.control/Scripts/MetadataAsCodeControl.sql
+++ b/src/metadata.control/Scripts/MetadataAsCodeControl.sql
@@ -1,0 +1,25 @@
+--Metadata As Code Control
+
+-- Add batches, stages and the links between them to the metadata control table.
+EXEC ##AddStages 'Raw', 'Extract/Ingest all data from source systems.', 1
+EXEC ##AddStages 'Cleansed', 'Merge Raw data into Delta Tables.', 1
+EXEC ##AddStages 'Curated', 'Transform cleansed data and apply business logic.', 1
+EXEC ##AddStages 'Serve', 'Load Curated data into semantic layer.', 1
+EXEC ##AddStages 'Speed', 'Regular loading of frequently used data.', 0
+EXEC ##AddStages 'ControlRaw', 'Demo of wait pipelines representing Raw load .', 0
+EXEC ##AddStages 'ControlCleansed', 'Demo of wait pipelines representing cleansed load.', 0
+EXEC ##AddStages 'ControlSpeed', 'Demo of wait pipelines loading of frequently used data.', 0
+
+EXEC ##AddBatches 'ControlDemoHourly', 'Ad-hoc Demo Batch for Control Wait pipeline executions.', 1
+EXEC ##AddBatches 'Hourly', 'Hourly Worker Pipelines.', 1
+EXEC ##AddBatches 'Daily', 'Daily Worker Pipelines.', 1
+EXEC ##AddBatches 'ControlDemoDaily', 'Ad-hoc Demo Batch for Control Wait pipeline executions.', 1
+
+EXEC ##AddBatchStageLink 'ControlDemoHourly', 'ControlSpeed'
+EXEC ##AddBatchStageLink 'Hourly', 'Speed'
+EXEC ##AddBatchStageLink 'Daily', 'Raw'
+EXEC ##AddBatchStageLink 'Daily', 'Cleansed'
+EXEC ##AddBatchStageLink 'Daily', 'Curated'
+EXEC ##AddBatchStageLink 'Daily', 'Serve'
+EXEC ##AddBatchStageLink 'ControlDemoDaily', 'ControlRaw'
+EXEC ##AddBatchStageLink 'ControlDemoDaily', 'ControlCleansed'

--- a/src/metadata.control/Scripts/Script.PostDeployment.sql
+++ b/src/metadata.control/Scripts/Script.PostDeployment.sql
@@ -11,6 +11,7 @@ Post-Deployment Script Template
 */
 --load default metadata
 :r .\DefaultProperties.sql
+:r .\MetadataAsCodeControl.sql
 --:r .\Metadata\Orchestrators.sql
 --:r .\Metadata\Stages.sql
 --:r .\Metadata\Pipelines.sql

--- a/src/metadata.control/control/Stored Procedures/AddBatchStageLink.sql
+++ b/src/metadata.control/control/Stored Procedures/AddBatchStageLink.sql
@@ -1,0 +1,40 @@
+CREATE PROCEDURE ##AddBatchStageLink
+(
+	@BatchName VARCHAR(255),
+	@StageName VARCHAR(255)
+)
+AS
+BEGIN
+	SET NOCOUNT ON;
+	DECLARE @BatchStageLink TABLE (
+		BatchId UNIQUEIDENTIFIER NOT NULL,
+		StageId INT NOT NULL
+	)
+
+	DECLARE @BatchId UNIQUEIDENTIFIER;
+	DECLARE @StageId INT;
+
+	SELECT 
+		@BatchId = b.BatchId
+	FROM control.Batches AS b
+	WHERE b.BatchName = @BatchName;
+
+	SELECT
+		@StageId = s.StageId
+	FROM control.Stages AS s
+	WHERE s.StageName = @StageName;
+
+	INSERT INTO @BatchStageLink (BatchId, StageId)
+	VALUES (@BatchId,@StageId)
+
+	MERGE INTO control.BatchStageLink AS Target
+	USING @BatchStageLink AS Source
+	ON Source.BatchId = Target.BatchId 
+	AND Source.StageId = Target.StageId
+
+	WHEN NOT MATCHED BY Target THEN
+		INSERT (BatchId, StageId) 
+		VALUES (Source.BatchId, Source.StageId)
+	;
+END
+GO

--- a/src/metadata.control/control/Stored Procedures/AddBatches.sql
+++ b/src/metadata.control/control/Stored Procedures/AddBatches.sql
@@ -1,0 +1,30 @@
+CREATE PROCEDURE ##AddBatches
+(
+	@BatchName VARCHAR(255),
+	@BatchDescription VARCHAR(4000),
+	@Enabled BIT
+)
+AS
+BEGIN
+	SET NOCOUNT ON;
+	WITH cte AS 
+	(
+		SELECT
+		@BatchName AS BatchName,
+		@BatchDescription AS BatchDescription,
+		@Enabled AS Enabled
+	)
+	MERGE INTO control.Batches AS Target
+	USING cte AS Source
+	ON Source.BatchName = Target.BatchName
+
+	WHEN NOT MATCHED THEN
+		INSERT (BatchName, BatchDescription, Enabled) 
+		VALUES (Source.BatchName, Source.BatchDescription, Source.Enabled)
+
+	WHEN MATCHED THEN UPDATE SET
+		Target.BatchDescription	= Source.BatchDescription,
+		Target.Enabled			= Source.Enabled
+	;
+END
+GO

--- a/src/metadata.control/control/Stored Procedures/AddOrchestrators.sql
+++ b/src/metadata.control/control/Stored Procedures/AddOrchestrators.sql
@@ -1,0 +1,40 @@
+CREATE PROCEDURE ##AddOrchestrators
+(
+	@OrchestratorName NVARCHAR(200),
+	@OrchestratorType CHAR(3),
+	@IsFrameworkOrchestrator BIT,
+	@ResourceGroupName NVARCHAR(200),
+	@subscriptionId	UNIQUEIDENTIFIER,
+	@Description NVARCHAR(MAX)
+)
+AS
+BEGIN
+	SET NOCOUNT ON;
+	WITH cte AS
+	(
+		SELECT
+		@OrchestratorName AS OrchestratorName,
+		@OrchestratorType AS OrchestratorType,
+		@IsFrameworkOrchestrator AS IsFrameworkOrchestrator,
+		@ResourceGroupName AS ResourceGroupName,
+		@subscriptionId	AS SubscriptionId,
+		@Description AS Description
+	)
+
+	MERGE INTO control.Orchestrators AS Target
+	USING cte AS Source
+	ON Source.OrchestratorName = Target.OrchestratorName
+
+	WHEN NOT MATCHED THEN
+		INSERT (OrchestratorName, OrchestratorType, IsFrameworkOrchestrator, ResourceGroupName, SubscriptionId, Description) 
+		VALUES (source.OrchestratorName, source.OrchestratorType, source.IsFrameworkOrchestrator, source.ResourceGroupName, source.SubscriptionId, source.Description)
+
+	WHEN MATCHED THEN UPDATE SET
+		Target.OrchestratorType			= Source.OrchestratorType,
+		Target.IsFrameworkOrchestrator	= Source.IsFrameworkOrchestrator,
+		Target.ResourceGroupName		= Source.ResourceGroupName,
+		Target.SubscriptionId			= Source.SubscriptionId,
+		Target.Description				= Source.Description
+	;
+END
+GO

--- a/src/metadata.control/control/Stored Procedures/AddStages.sql
+++ b/src/metadata.control/control/Stored Procedures/AddStages.sql
@@ -1,0 +1,30 @@
+CREATE PROCEDURE ##AddStages
+(
+	@StageName VARCHAR(255),
+	@StageDescription VARCHAR(4000),
+	@Enabled BIT
+)
+AS
+BEGIN
+	SET NOCOUNT ON;
+	WITH cte AS
+	(
+		SELECT
+		@StageName AS StageName,
+		@StageDescription AS StageDescription,
+		@Enabled AS Enabled
+	)
+	MERGE INTO control.Stages AS Target
+	USING cte AS Source
+	ON Source.StageName = Target.StageName
+
+	WHEN NOT MATCHED THEN
+		INSERT (StageName, StageDescription, Enabled) 
+		VALUES (Source.StageName, Source.StageDescription, Source.Enabled)
+
+	WHEN MATCHED THEN UPDATE SET
+		Target.StageDescription	= Source.StageDescription,
+		Target.Enabled			= Source.Enabled
+	;
+END
+GO

--- a/src/metadata.control/control/Stored Procedures/AddSubscriptions.sql
+++ b/src/metadata.control/control/Stored Procedures/AddSubscriptions.sql
@@ -1,0 +1,33 @@
+CREATE PROCEDURE ##AddSubscriptions
+(
+	@SubscriptionId UNIQUEIDENTIFIER,
+	@Name NVARCHAR(200),
+	@Description NVARCHAR(MAX),
+	@TenantId UNIQUEIDENTIFIER
+)
+AS
+BEGIN
+	SET NOCOUNT ON;
+	WITH cte AS
+	(
+		SELECT
+		@SubscriptionId AS SubscriptionId,
+		@Name AS Name,
+		@Description AS Description,
+		@TenantId AS TenantId
+	)
+	MERGE INTO control.Subscriptions AS Target
+	USING cte AS Source
+	ON Source.SubscriptionId = Target.SubscriptionId
+
+	WHEN NOT MATCHED THEN
+		INSERT (SubscriptionId, Name, Description, TenantId) 
+		VALUES (Source.SubscriptionId, Source.Name, Source.Description, Source.TenantId)
+
+	WHEN MATCHED THEN UPDATE SET
+		Target.Name			= Source.Name,
+		Target.Description	= Source.Description,
+		Target.TenantID		= Source.TenantId
+	;
+END
+GO

--- a/src/metadata.control/control/Stored Procedures/AddTenants.sql
+++ b/src/metadata.control/control/Stored Procedures/AddTenants.sql
@@ -1,0 +1,30 @@
+CREATE PROCEDURE ##AddTenants
+(
+	@TenantId UNIQUEIDENTIFIER,
+	@Name NVARCHAR(200),
+	@Description NVARCHAR(MAX)
+)
+AS
+BEGIN
+	SET NOCOUNT ON;
+	WITH cte AS
+	(
+		SELECT
+		@TenantId AS TenantId,
+		@Name AS Name,
+		@Description AS Description
+	)
+	MERGE INTO control.Tenants AS Target
+	USING cte AS Source
+	ON Source.TenantId = Target.TenantId
+
+	WHEN NOT MATCHED THEN
+		INSERT (TenantId, Name, Description) 
+		VALUES (Source.TenantId, Source.Name, Source.Description)
+
+	WHEN MATCHED THEN UPDATE SET
+		Target.Name			= Source.Name,
+		Target.Description	= Source.Description
+	;
+END
+GO

--- a/src/metadata.control/metadata.control.sqlproj
+++ b/src/metadata.control/metadata.control.sqlproj
@@ -128,6 +128,12 @@
     <Build Include="control\Stored Procedures\GetFrameworkOrchestratorDetails.sql" />
     <Build Include="control\Stored Procedures\AddProperty.sql" />
     <Build Include="control\Stored Procedures\GetWorkerPipelineDetailsv2.sql" />
+	<Build Include="control\Stored Procedures\AddBatches.sql" />
+	<Build Include="control\Stored Procedures\AddBatchStageLink.sql" />
+	<Build Include="control\Stored Procedures\AddOrchestrators.sql" />
+	<Build Include="control\Stored Procedures\AddStages.sql" />
+	<Build Include="control\Stored Procedures\AddSubscriptions.sql" />
+	<Build Include="control\Stored Procedures\AddTenants.sql" />
   </ItemGroup>
   <ItemGroup>
     <PostDeploy Include="Scripts\Script.PostDeployment.sql" />
@@ -135,6 +141,7 @@
   <ItemGroup>
     <None Include="metadata.control.publish.xml" />
     <None Include="Scripts\DefaultProperties.sql" />
+	<None Include="Scripts\MetadataAsCodeControl.sql" />
     <None Include="Security\db_cumulususer.sql" />
   </ItemGroup>
   <ItemGroup>

--- a/src/metadata.ingest/Scripts/MetadataAsCodeIngestSample.sql
+++ b/src/metadata.ingest/Scripts/MetadataAsCodeIngestSample.sql
@@ -1,0 +1,60 @@
+-- Metadata As Code - Ingest - add sample Datasets
+
+--Datasets:
+EXEC ##AddDatasets 'AdventureWorksDemo', 'Ingest_LS_SQLDB_MIAuth', 'CumulusDemoDataSource01', 'CF.Cumulus.Ingest.Compute', 'SalesOrderHeader', 'SalesLT', 'SalesOrderHeader', 'parquet', 1, '2025-01-01 00:00:00.0000000', NULL, 'I', 0, 0, 'WHERE ModifiedDate > GETDATE() - 7', 'SalesLT', 'SalesOrderHeader', 1;
+EXEC ##AddDatasets 'AdventureWorksDemo', 'Ingest_LS_SQLDB_MIAuth', 'CumulusDemoDataSource01', 'CF.Cumulus.Ingest.Compute', 'SalesOrderDetail', 'SalesLT', 'SalesOrderDetail', 'parquet', 1, '2025-01-01 00:00:00.0000000', NULL, 'I', 0, 0, 'WHERE ModifiedDate > GETDATE() - 7', 'SalesLT', 'SalesOrderDetail', 1;
+EXEC ##AddDatasets 'AdventureWorksDemo', 'Ingest_LS_SQLDB_MIAuth', 'CumulusDemoDataSource01', 'CF.Cumulus.Ingest.Compute', 'Product', 'SalesLT', 'Product', 'parquet', 1, '2025-01-01 00:00:00.0000000', NULL, 'I', 0, 0, 'WHERE ModifiedDate > GETDATE() - 7', 'SalesLT', 'Product', 1;
+
+--Attributes for SalesOrderHeader
+EXEC ##AddAttributes 'AdventureWorksDemo', 'SalesOrderHeader', 1, 'SalesOrderID', 'int', 'INTEGER', '', '', 1, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'SalesOrderHeader', 1, 'RevisionNumber', 'tinyint', 'INTEGER', '', '', 0, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'SalesOrderHeader', 1, 'OrderDate', 'datetime', 'TIMESTAMP', 'yyyy-MM-dd HH:mm:ss', '', 0, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'SalesOrderHeader', 1, 'DueDate', 'datetime', 'TIMESTAMP', 'yyyy-MM-dd HH:mm:ss', '', 0, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'SalesOrderHeader', 1, 'ShipDate', 'datetime', 'TIMESTAMP', 'yyyy-MM-dd HH:mm:ss', '', 0, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'SalesOrderHeader', 1, 'Status', 'tinyint', 'INTEGER', '', '', 0, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'SalesOrderHeader', 1, 'OnlineOrderFlag', 'bit', 'BOOLEAN', '', '', 0, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'SalesOrderHeader', 1, 'SalesOrderNumber', 'nvarchar(25)', 'STRING', '', '', 0, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'SalesOrderHeader', 1, 'PurchaseOrderNumber', 'nvarchar(25)', 'STRING', '', '', 0, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'SalesOrderHeader', 1, 'AccountNumber', 'nvarchar(15)', 'STRING', '', '', 0, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'SalesOrderHeader', 1, 'CustomerID', 'int', 'INTEGER', '', '', 0, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'SalesOrderHeader', 1, 'ShipToAddressID', 'int', 'INTEGER', '', '', 0, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'SalesOrderHeader', 1, 'BillToAddressID', 'int', 'INTEGER', '', '', 0, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'SalesOrderHeader', 1, 'ShipMethod', 'nvarchar(50)', 'STRING', '', '', 0, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'SalesOrderHeader', 1, 'CreditCardApprovalCode', 'varchar', 'STRING', '', '', 0, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'SalesOrderHeader', 1, 'SubTotal', 'money', 'INTEGER', '', '', 0, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'SalesOrderHeader', 1, 'TaxAmt', 'money', 'INTEGER', '', '', 0, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'SalesOrderHeader', 1, 'Freight', 'money', 'INTEGER', '', '', 0, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'SalesOrderHeader', 1, 'TotalDue', 'money', 'INTEGER', '', '', 0, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'SalesOrderHeader', 1, 'Comment', 'nvarchar(-1)', 'STRING', '', '', 0, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'SalesOrderHeader', 1, 'rowguid', 'uniqueidentifier', 'STRING', '', '', 0, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'SalesOrderHeader', 1, 'ModifiedDate', 'datetime', 'TIMESTAMP', 'yyyy-MM-dd HH:mm:ss', '', 0, 0, 1
+
+--Attributes for SalesOrderDetail
+EXEC ##AddAttributes 'AdventureWorksDemo', 'SalesOrderDetail', 1, 'SalesOrderID', 'int', 'INTEGER', '', '', 1, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'SalesOrderDetail', 1, 'SalesOrderDetailID', 'int', 'INTEGER', '', '', 1, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'SalesOrderDetail', 1, 'OrderQty', 'smallint', 'INTEGER', '', '', 0, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'SalesOrderDetail', 1, 'ProductID', 'int', 'INTEGER', '', '', 0, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'SalesOrderDetail', 1, 'UnitPrice', 'money', 'INTEGER', '', '', 0, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'SalesOrderDetail', 1, 'UnitPriceDiscount', 'money', 'INTEGER', '', '', 0, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'SalesOrderDetail', 1, 'LineTotal', 'numeric', 'INTEGER', '', '', 0, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'SalesOrderDetail', 1, 'rowguid', 'uniqueidentifier', 'STRING', '', '', 0, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'SalesOrderDetail', 1, 'ModifiedDate', 'datetime', 'TIMESTAMP', 'yyyy-MM-dd HH:mm:ss', '', 0, 0, 1
+
+--Attributes for Product
+EXEC ##AddAttributes 'AdventureWorksDemo', 'Product', 1, 'ProductID', 'int', 'INTEGER', '', '', 1, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'Product', 1, 'Name', 'nvarchar(50)', 'STRING', '', '', 0, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'Product', 1, 'ProductNumber', 'nvarchar(25)', 'STRING', '', '', 0, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'Product', 1, 'Color', 'nvarchar(15)', 'STRING', '', '', 0, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'Product', 1, 'StandardCost', 'money', 'INTEGER', '', '', 0, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'Product', 1, 'ListPrice', 'money', 'INTEGER', '', '', 0, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'Product', 1, 'Size', 'nvarchar(5)', 'STRING', '', '', 0, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'Product', 1, 'Weight', 'decimal(8,2)', 'FLOAT', '', '', 0, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'Product', 1, 'ProductCategoryID', 'int', 'INTEGER', '', '', 0, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'Product', 1, 'ProductModelID', 'int', 'INTEGER', '', '', 0, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'Product', 1, 'SellStartDate', 'datetime', 'TIMESTAMP', 'yyyy-MM-dd HH:mm:ss', '', 0, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'Product', 1, 'SellEndDate', 'datetime', 'TIMESTAMP', 'yyyy-MM-dd HH:mm:ss', '', 0, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'Product', 1, 'DiscontinuedDate', 'datetime', 'TIMESTAMP', 'yyyy-MM-dd HH:mm:ss', '', 0, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'Product', 1, 'ThumbNailPhoto', 'varbinary', 'BINARY', '', '', 0, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'Product', 1, 'ThumbnailPhotoFileName', 'nvarchar(50)', 'STRING', '', '', 0, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'Product', 1, 'rowguid', 'uniqueidentifier', 'STRING', '', '', 0, 0, 1
+EXEC ##AddAttributes 'AdventureWorksDemo', 'Product', 1, 'ModifiedDate', 'datetime', 'TIMESTAMP', 'yyyy-MM-dd HH:mm:ss', '', 0, 0, 1

--- a/src/metadata.ingest/Scripts/Script.PostDeployment.sql
+++ b/src/metadata.ingest/Scripts/Script.PostDeployment.sql
@@ -9,4 +9,4 @@ Post-Deployment Script Template
                SELECT * FROM [$(TableName)]					
 --------------------------------------------------------------------------------------
 */
-
+:r .\MetadataAsCodeIngestSample.sql

--- a/src/metadata.ingest/ingest/Stored Procedures/AddAttributes.sql
+++ b/src/metadata.ingest/ingest/Stored Procedures/AddAttributes.sql
@@ -1,0 +1,91 @@
+CREATE PROCEDURE ##AddAttributes
+(
+	@ConnectionDisplayName NVARCHAR(50),
+	@DatasetDisplayName NVARCHAR(50),
+	@VersionNumber INT,
+	@AttributeName NVARCHAR(50),
+	@AttributeSourceDataType NVARCHAR(50),
+	@AttributeTargetDataType NVARCHAR(50),
+	@AttributeTargetDataFormat NVARCHAR(500),
+	@AttributeDescription NVARCHAR(500),
+	@PKAttribute BIT,
+	@PartitionByAttribute BIT,
+	@Enabled BIT
+
+)
+AS
+BEGIN
+	SET NOCOUNT ON;
+	DECLARE @Attributes TABLE (
+		ConnectionFK INT NOT NULL,
+		ConnectionDisplayName NVARCHAR(50) NOT NULL,
+		DatasetFK INT NOT NULL,
+		DatasetDisplayName NVARCHAR(50) NOT NULL,
+		VersionNumber INT,
+		AttributeName NVARCHAR(50) NOT NULL,
+		AttributeSourceDataType NVARCHAR(50) NOT NULL,
+		AttributeTargetDataType NVARCHAR(50) NOT NULL,
+		AttributeTargetDataFormat NVARCHAR(500) NOT NULL,
+		AttributeDescription NVARCHAR(500) NULL,
+		PKAttribute BIT NOT NULL,
+		PartitionByAttribute BIT NOT NULL,
+		Enabled BIT NOT NULL
+	)
+
+	INSERT INTO @Attributes(ConnectionFK,ConnectionDisplayName,DatasetFK,DatasetDisplayName,VersionNumber,AttributeName,AttributeSourceDataType,AttributeTargetDataType,AttributeTargetDataFormat,AttributeDescription,PKAttribute,PartitionByAttribute,Enabled)
+	VALUES (-1,@ConnectionDisplayName,-1,@DatasetDisplayName,@VersionNumber,@AttributeName,@AttributeSourceDataType,@AttributeTargetDataType,@AttributeTargetDataFormat,@AttributeDescription,@PKAttribute,@PartitionByAttribute,@Enabled)
+
+	UPDATE a
+	SET a.DatasetFK = d.DatasetId
+	FROM @Attributes AS a
+	INNER JOIN ingest.Datasets AS d
+	ON d.DatasetDisplayName = a.DatasetDisplayName
+	AND d.VersionNumber = a.VersionNumber
+
+	IF (SELECT DatasetFK FROM @Attributes) = -1
+	BEGIN
+		RAISERROR('DatasetFK not updated as the DatasetDisplayName does not exist within ingest.Datasets.',16,1)
+		RETURN 0;
+	END
+
+	UPDATE a
+	SET a.ConnectionFK = c.ConnectionId
+	FROM @Attributes AS a
+	INNER JOIN common.Connections AS c 
+	ON c.ConnectionDisplayName = a.ConnectionDisplayName
+
+	IF (SELECT ConnectionFK FROM @Attributes) = -1
+	BEGIN
+		RAISERROR('ConnectionFK not updated as the ConnectionDisplayName does not exist within common.Connections.',16,1)
+		RETURN 0;
+	END
+ 
+	MERGE INTO ingest.Attributes AS Target
+	USING @Attributes AS Source
+	ON Source.DatasetFK = Target.DatasetFK
+	AND Source.AttributeName = Target.AttributeName
+
+	WHEN NOT MATCHED THEN
+		INSERT (DatasetFK,AttributeName,AttributeSourceDataType,AttributeTargetDataType,AttributeTargetDataFormat,AttributeDescription,PKAttribute,PartitionByAttribute,Enabled)
+		VALUES (
+			Source.DatasetFK,
+			Source.AttributeName,
+			Source.AttributeSourceDataType,
+			Source.AttributeTargetDataType,
+			Source.AttributeTargetDataFormat,
+			Source.AttributeDescription,
+			Source.PKAttribute,
+			Source.PartitionByAttribute,
+			Source.Enabled
+			)
+
+	WHEN MATCHED THEN UPDATE SET
+		Target.AttributeSourceDataType = Source.AttributeSourceDataType,
+		Target.AttributeTargetDataType = Source.AttributeTargetDataType,
+		Target.AttributeTargetDataFormat = Source.AttributeTargetDataFormat,
+		Target.AttributeDescription = Source.AttributeDescription,
+		Target.PKAttribute = Source.PKAttribute,
+		Target.PartitionByAttribute = Source.PartitionByAttribute,
+		Target.Enabled = Source.Enabled
+	;
+END

--- a/src/metadata.ingest/ingest/Stored Procedures/AddDatasets.sql
+++ b/src/metadata.ingest/ingest/Stored Procedures/AddDatasets.sql
@@ -1,0 +1,144 @@
+CREATE PROCEDURE ##AddDatasets
+(
+	@ConnectionDisplayName NVARCHAR(50),
+	@LinkedServiceName NVARCHAR(200),
+	@ResourceName NVARCHAR(100),
+	@ComputeConnectionDisplayName NVARCHAR(50),
+	@DatasetDisplayName NVARCHAR(50),
+	@SourcePath NVARCHAR(100),
+	@SourceName NVARCHAR(100),
+	@ExtensionType NVARCHAR(100),
+	@VersionNumber INT,
+	@VersionValidFrom DATETIME2(7),
+	@VersionValidTo DATETIME2(7),
+	@LoadType CHAR(1),
+	@LoadStatus INT,
+	@OverrideLoadStatus BIT,
+	@LoadClause NVARCHAR(MAX),
+	@CleansedPath NVARCHAR(100),
+	@CleansedName NVARCHAR(100),
+	@Enabled BIT
+
+)
+AS
+BEGIN
+	SET NOCOUNT ON;
+	DECLARE @Datasets TABLE (
+		ConnectionFK INT NOT NULL,
+		ConnectionDisplayName NVARCHAR(50),
+		LinkedServiceName NVARCHAR(200),
+		ResourceName NVARCHAR(100),
+		MergeComputeConnectionFK INT,
+		ComputeConnectionDisplayName NVARCHAR(50),
+		DatasetDisplayName NVARCHAR(50) NOT NULL,
+		SourcePath NVARCHAR(100) NOT NULL,
+		SourceName NVARCHAR(100)NOT NULL,
+		ExtensionType NVARCHAR(100),
+		VersionNumber INT NOT NULL,
+		VersionValidFrom DATETIME2(7),
+		VersionValidTo DATETIME2(7),
+		LoadType CHAR(1) NOT NULL,
+		LoadStatus INT NOT NULL,
+		OverrideLoadStatus BIT NOT NULL,
+		LoadClause NVARCHAR(MAX),
+		CleansedPath NVARCHAR(100) NOT NULL,
+		CleansedName NVARCHAR(100) NOT NULL,
+		Enabled BIT NOT NULL
+	)
+
+	INSERT INTO @Datasets(ConnectionFK, ConnectionDisplayName, LinkedServiceName, ResourceName, MergeComputeConnectionFK, ComputeConnectionDisplayName, 
+						DatasetDisplayName, SourcePath, SourceName, ExtensionType, VersionNumber, VersionValidFrom, VersionValidTo, 
+						LoadType, LoadStatus, OverrideLoadStatus, LoadClause, CleansedPath, CleansedName, Enabled)
+	VALUES (-1, @ConnectionDisplayName, @LinkedServiceName, @ResourceName, -1, @ComputeConnectionDisplayName, @DatasetDisplayName, @SourcePath, @SourceName, 
+			@ExtensionType, @VersionNumber, @VersionValidFrom, @VersionValidTo, @LoadType, @LoadStatus, @OverrideLoadStatus, @LoadClause, 
+			@CleansedPath, @CleansedName, @Enabled)
+
+	UPDATE d
+	SET d.ConnectionFK = c.ConnectionId
+	FROM @Datasets AS d
+	INNER JOIN common.Connections AS c
+	ON c.ConnectionDisplayName = d.ConnectionDisplayName
+	AND c.LinkedServiceName = d.LinkedServiceName
+	AND c.ResourceName = d.ResourceName
+
+	IF (SELECT ConnectionFK FROM @Datasets) = -1
+	BEGIN
+		RAISERROR('ConnectionFK not updated as the ConnectionDisplayName / LinkedServiceName combination of values does not exist within common.ConnectionTypes.',16,1)
+		RETURN 0;
+	END
+
+	UPDATE d
+	SET d.MergeComputeConnectionFK = c.ComputeConnectionId
+	FROM @Datasets AS d
+	INNER JOIN common.ComputeConnections AS c
+	ON c.ConnectionDisplayName = d.ComputeConnectionDisplayName
+
+
+	IF (SELECT MergeComputeConnectionFK FROM @Datasets) = -1
+	BEGIN
+		RAISERROR('MergeComputeConnectionFK not updated as the ComputeConnectionTypeDisplayName does not exist within common.ComputeConnections.',16,1)
+		RETURN 0;
+	END
+
+	MERGE INTO ingest.Datasets AS Target
+	USING @Datasets AS Source
+	ON Source.DatasetDisplayName = Target.DatasetDisplayName
+
+	WHEN NOT MATCHED THEN
+		INSERT (ConnectionFK, 
+				MergeComputeConnectionFK, 
+				DatasetDisplayName, 
+				SourcePath, 
+				SourceName, 
+				ExtensionType, 
+				VersionNumber, 
+				VersionValidFrom, 
+				VersionValidTo, 
+				LoadType, 
+				LoadStatus, 
+				LoadClause, 
+				RawLastFullLoadDate, 
+				RawLastIncrementalLoadDate, 
+				CleansedPath, 
+				CleansedName, 
+				CleansedLastFullLoadDate, 
+				CleansedLastIncrementalLoadDate, 
+				Enabled)
+		VALUES (Source.ConnectionFK, 
+				Source.MergeComputeConnectionFK, 
+				Source.DatasetDisplayName, 
+				Source.SourcePath, 
+				Source.SourceName, 
+				Source.ExtensionType, 
+				Source.VersionNumber, 
+				Source.VersionValidFrom, 
+				Source.VersionValidTo, 
+				Source.LoadType, 
+				CASE WHEN Source.OverrideLoadStatus = 1 THEN Source.LoadStatus ELSE 0 END, 
+				Source.LoadClause, 
+				NULL, 
+				NULL, 
+				Source.CleansedPath, 
+				Source.CleansedName,
+				NULL, 
+				NULL, 
+				Source.Enabled)
+
+	WHEN MATCHED THEN UPDATE SET
+		Target.ConnectionFK = Source.ConnectionFK,
+		Target.MergeComputeConnectionFK = Source.MergeComputeConnectionFK,
+		Target.SourcePath = Source.SourcePath,
+		Target.SourceName = Source.SourceName,
+		Target.ExtensionType = Source.ExtensionType,
+		Target.VersionNumber = Source.VersionNumber,
+		Target.VersionValidFrom = Source.VersionValidFrom,
+		Target.VersionValidTo = Source.VersionValidTo,
+		Target.LoadType = Source.LoadType,
+		Target.LoadStatus = CASE WHEN Source.OverrideLoadStatus = 1 THEN Source.LoadStatus ELSE Target.LoadStatus END,
+		Target.LoadClause = Source.LoadClause,
+		Target.CleansedPath = Source.CleansedPath,
+		Target.CleansedName = Source.CleansedName,
+		Target.Enabled = Source.Enabled
+	;
+END
+GO

--- a/src/metadata.ingest/ingest/Stored Procedures/AddDatasets.sql
+++ b/src/metadata.ingest/ingest/Stored Procedures/AddDatasets.sql
@@ -83,6 +83,8 @@ BEGIN
 	MERGE INTO ingest.Datasets AS Target
 	USING @Datasets AS Source
 	ON Source.DatasetDisplayName = Target.DatasetDisplayName
+	AND Source.ConnectionFK = Target.ConnectionFK
+
 
 	WHEN NOT MATCHED THEN
 		INSERT (ConnectionFK, 
@@ -125,7 +127,6 @@ BEGIN
 				Source.Enabled)
 
 	WHEN MATCHED THEN UPDATE SET
-		Target.ConnectionFK = Source.ConnectionFK,
 		Target.MergeComputeConnectionFK = Source.MergeComputeConnectionFK,
 		Target.SourcePath = Source.SourcePath,
 		Target.SourceName = Source.SourceName,

--- a/src/metadata.ingest/metadata.ingest.sqlproj
+++ b/src/metadata.ingest/metadata.ingest.sqlproj
@@ -72,12 +72,15 @@
     <Build Include="ingest\Stored Procedures\GetDatasetPayload.sql" />
     <Build Include="ingest\Stored Procedures\GetMergePayload.sql" />
     <Build Include="ingest\Stored Procedures\SetIngestLoadStatus.sql" />
+	<Build Include="ingest\Stored Procedures\AddDatasets.sql" />
+	<Build Include="ingest\Stored Procedures\AddAttributes.sql" />
     <Build Include="ingest\Functions\GetIngestLoadAction.sql">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Build>
     <Build Include="Scripts\DynamicsGetAttributeMetadata.sql" />
     <Build Include="Scripts\OracleGetAttributeMetadata.sql" />
     <Build Include="Scripts\SqlGetAttributeMetadata.sql" />
+	<None Include="Scripts\MetadataAsCodeIngestSample.sql" />
     <Build Include="Security\db_cumulususer.sql" />
     <Build Include="Security\ingest.sql" />
     <Build Include="ingest\Stored Procedures\AddIngestPayloadPipelineDependencies.sql" />

--- a/src/metadata.transform/Scripts/MetadataAsCodeTransform.sql
+++ b/src/metadata.transform/Scripts/MetadataAsCodeTransform.sql
@@ -1,0 +1,17 @@
+--Metadata As Code Transform
+
+--Notebook Types
+EXEC ##AddNotebookTypes 'Unmanaged', 1
+EXEC ##AddNotebookTypes 'Managed', 1
+EXEC ##AddNotebookTypes 'Create Dimension Table', 1
+EXEC ##AddNotebookTypes 'Create Fact Table', 1
+
+EXEC ##AddNotebooks 'Unmanaged', 'UnmanagedQuery', '/Workspace/Shared/Live/transform/unmanagednotebooks/UnmanagedQuery', 1
+EXEC ##AddNotebooks 'Unmanaged', 'CreateDimDate', '/Workspace/Shared/Live/transform/unmanagednotebooks/CreateDimDate', 1
+EXEC ##AddNotebooks 'Unmanaged', 'CreateDimProducts', '/Workspace/Shared/Live/transform/unmanagednotebooks/CreateDimProducts', 1
+EXEC ##AddNotebooks 'Unmanaged', 'CreateFactSales', '/Workspace/Shared/Live/transform/unmanagednotebooks/CreateFactSales', 1
+
+EXEC ##AddTransformDatasets 'CF.Cumulus.Transform.Compute', 'UnmanagedQuery', 'UnmanagedQuery', 'Samples', 'NYCTaxiTrip', 1, NULL, NULL, 'F', 0, NULL, 1
+EXEC ##AddTransformDatasets 'CF.Cumulus.Transform.Compute', 'CreateDimDate', 'CreateDimDate', 'Curated', 'DimDate', 1, NULL, NULL, 'F', 0, NULL, 1
+EXEC ##AddTransformDatasets 'CF.Cumulus.Transform.Compute', 'CreateDimProducts', 'CreateDimProducts', 'Curated', 'DimProducts', 1, NULL, NULL, 'F', 0, NULL, 1
+EXEC ##AddTransformDatasets 'CF.Cumulus.Transform.Compute', 'CreateFactSales', 'CreateFactSales', 'Curated', 'FactSales', 1, NULL, NULL, 'F', 0, NULL, 1

--- a/src/metadata.transform/Scripts/Script.PostDeployment.sql
+++ b/src/metadata.transform/Scripts/Script.PostDeployment.sql
@@ -9,3 +9,4 @@ Post-Deployment Script Template
                SELECT * FROM [$(TableName)]					
 --------------------------------------------------------------------------------------
 */
+:r .\MetadataAsCodeTransform.sql

--- a/src/metadata.transform/metadata.transform.sqlproj
+++ b/src/metadata.transform/metadata.transform.sqlproj
@@ -75,9 +75,14 @@
     <Build Include="transform\Stored Procedures\GetNotebookPayload.sql" />
     <Build Include="transform\Stored Procedures\SetTransformLoadStatus.sql" />
     <Build Include="transform\Stored Procedures\GetUnmanagedNotebookPayload.sql" />
+	<Build Include="transform\Stored Procedures\AddAttributes.sql" />
+	<Build Include="transform\Stored Procedures\AddDatasets.sql" />
+	<Build Include="transform\Stored Procedures\AddNotebooks.sql" />
+	<Build Include="transform\Stored Procedures\AddNotebookTypes.sql" />
     <Build Include="Synonyms\ComputeConnections.sql" />
     <Build Include="Synonyms\Connections.sql" />
     <Build Include="Synonyms\ConnectionTypes.sql" />
+	<None Include="Scripts\MetadataAsCodeTransform.sql" />
   </ItemGroup>
   <ItemGroup>
     <PreDeploy Include="Scripts\Script.PreDeployment.sql" />

--- a/src/metadata.transform/transform/Stored Procedures/AddAttributes.sql
+++ b/src/metadata.transform/transform/Stored Procedures/AddAttributes.sql
@@ -1,0 +1,71 @@
+CREATE PROCEDURE ##AddTransformAttributes
+(
+	@DatasetName NVARCHAR(100),
+	@DatasetSchema NVARCHAR(100),
+	@AttributeName NVARCHAR(100),
+	@AttributeTargetDataType NVARCHAR(50),
+	@AttributeDescription NVARCHAR(200),
+	@BKAttribute BIT,
+	@SurrogateKeyAttribute BIT,
+	@PartitionByAttribute BIT,
+	@Enabled BIT
+)
+AS
+BEGIN
+	SET NOCOUNT ON;
+	DECLARE @Attributes TABLE (
+		DatasetName NVARCHAR(100),
+		DatasetSchema NVARCHAR(100),
+		DatasetFK INT,
+		AttributeName NVARCHAR(100),
+		AttributeTargetDataType NVARCHAR(50),
+		AttributeDescription NVARCHAR(200),
+		BKAttribute BIT,
+		SurrogateKeyAttribute BIT,
+		PartitionByAttribute BIT,
+		Enabled BIT
+	)
+
+	INSERT INTO @Attributes(DatasetName, DatasetSchema, DatasetFK, AttributeName, AttributeTargetDataType, AttributeDescription, BKAttribute, SurrogateKeyAttribute, PartitionByAttribute, Enabled)
+	VALUES (@DatasetName, @DatasetSchema, -1, @AttributeName, @AttributeTargetDataType, @AttributeDescription, @BKAttribute, @SurrogateKeyAttribute, @PartitionByAttribute, @Enabled)
+
+	UPDATE a
+	SET a.DatasetFK = d.DatasetId
+	FROM @Attributes AS a
+	INNER JOIN transform.Datasets AS d
+	ON a.DatasetName = d.DatasetName
+	AND a.DatasetSchema = d.SchemaName
+
+	IF (SELECT DatasetFK FROM @Attributes) = -1
+	BEGIN
+		RAISERROR('DatasetFK not updated as a DatasetName with the SchemaName does not exist within transform.Datasets.',16,1)
+		RETURN 0;
+	END
+
+	MERGE INTO transform.Attributes AS Target
+	USING @Attributes AS Source
+	ON Source.AttributeName = Target.AttributeName
+	AND Source.DatasetFK = Target.DatasetFK
+
+	WHEN NOT MATCHED THEN
+		INSERT (DatasetFK, AttributeName, AttributeTargetDataType, AttributeDescription, BKAttribute, SurrogateKeyAttribute, PartitionByAttribute, Enabled)
+		VALUES (Source.DatasetFK,
+				Source.AttributeName,
+				Source.AttributeTargetDataType,
+				Source.AttributeDescription,
+				Source.BKAttribute,
+				Source.SurrogateKeyAttribute,
+				Source.PartitionByAttribute,
+				Source.Enabled)
+
+	WHEN MATCHED THEN UPDATE SET
+		Target.DatasetFK = Source.DatasetFK,
+		Target.AttributeTargetDataType = Source.AttributeTargetDataType,
+		Target.AttributeDescription = Source.AttributeDescription,
+		Target.BKAttribute = Source.BKAttribute,
+		Target.SurrogateKeyAttribute = Source.SurrogateKeyAttribute,
+		Target.PartitionByAttribute = Source.PartitionByAttribute,
+		Target.Enabled = Source.Enabled
+	;
+END
+GO

--- a/src/metadata.transform/transform/Stored Procedures/AddDatasets.sql
+++ b/src/metadata.transform/transform/Stored Procedures/AddDatasets.sql
@@ -1,0 +1,107 @@
+CREATE PROCEDURE ##AddTransformDatasets
+(
+	@ComputeConnectionDisplayName NVARCHAR(50),
+	@CreateNotebookName NVARCHAR(100),
+	@BusinessLogicName NVARCHAR(100),
+	@SchemaName NVARCHAR(100),
+	@DatasetName NVARCHAR(100),
+	@VersionNumber INT,
+	@VersionValidFrom DATETIME2(7),
+	@VersionValidTo DATETIME2(7),
+	@LoadType CHAR(1),
+	@LoadStatus INT,
+	@LastLoadDate DATETIME2(7),
+	@Enabled BIT
+)
+AS
+BEGIN
+	SET NOCOUNT ON;
+	DECLARE @TransformDatasets TABLE (
+		ComputeConnectionDisplayName NVARCHAR(50),
+		ComputeConnectionFK INT,
+		CreateNotebookName NVARCHAR(100),
+		CreateNotebookFK INT,
+		BusinessLogicName NVARCHAR(100),
+		BusinessLogicNotebookFK INT,
+		SchemaName NVARCHAR(100),
+		DatasetName NVARCHAR(100),
+		VersionNumber INT,
+		VersionValidFrom DATETIME2(7),
+		VersionValidTo DATETIME2(7),
+		LoadType CHAR(1),
+		LoadStatus INT,
+		LastLoadDate DATETIME2(7),
+		Enabled BIT
+	)
+
+	INSERT INTO @TransformDatasets(ComputeConnectionDisplayName, ComputeConnectionFK, CreateNotebookName, CreateNotebookFK, BusinessLogicName, BusinessLogicNotebookFK, SchemaName, DatasetName, VersionNumber, VersionValidFrom, VersionValidTo, LoadType, LoadStatus, LastLoadDate, Enabled)
+	VALUES (@ComputeConnectionDisplayName, -1, @CreateNotebookName, -1, @BusinessLogicName, -1, @SchemaName, @DatasetName, @VersionNumber, @VersionValidFrom, @VersionValidTo, @LoadType, @LoadStatus, @LastLoadDate, @Enabled)
+
+	UPDATE td
+	SET td.ComputeConnectionFK = c.ComputeConnectionId
+	FROM @TransformDatasets AS td
+	INNER JOIN common.ComputeConnections AS c
+	ON td.ComputeConnectionDisplayName = c.ConnectionDisplayName
+
+	IF (SELECT ComputeConnectionFK FROM @TransformDatasets) = -1
+	BEGIN
+		RAISERROR('ComputeConnectionFK not updated as the ComputeConnectionDisplayName does not exist within common.ComputeConnections.',16,1)
+		RETURN 0;
+	END
+
+	UPDATE td
+	SET td.CreateNotebookFK = n.NotebookId
+	FROM @TransformDatasets AS td
+	INNER JOIN transform.Notebooks AS n
+	ON td.CreateNotebookName = n.NotebookName
+
+	IF (SELECT CreateNotebookFK FROM @TransformDatasets) = -1
+	BEGIN
+		RAISERROR('CreateNotebookFK not updated as the CreateNotebookName does not exist within transform.notebooks.',16,1)
+		RETURN 0;
+	END
+
+	UPDATE td
+	SET td.BusinessLogicNotebookFK = n.NotebookId
+	FROM @TransformDatasets AS td
+	INNER JOIN transform.Notebooks AS n
+	ON td.BusinessLogicName = n.NotebookName
+
+	IF (SELECT BusinessLogicNotebookFK FROM @TransformDatasets) = -1
+	BEGIN
+		RAISERROR('BusinessLogicNotebookFK not updated as the BusinessLogicName does not exist within transform.notebooks.',16,1)
+		RETURN 0;
+	END
+
+	MERGE INTO transform.Datasets AS Target
+	USING @TransformDatasets AS Source
+	ON Source.DatasetName = Target.DatasetName
+	AND Source.SchemaName = Target.SchemaName
+
+	WHEN NOT MATCHED THEN
+		INSERT (ComputeConnectionFK, CreateNotebookFK, BusinessLogicNotebookFK, SchemaName, DatasetName, VersionNumber, VersionValidFrom, VersionValidTo, LoadType, LoadStatus, LastLoadDate, Enabled)
+		VALUES (Source.ComputeConnectionFK, 
+				Source.CreateNotebookFK, 
+				Source.BusinessLogicNotebookFK, 
+				Source.SchemaName, 
+				Source.DatasetName,  
+				Source.VersionNumber, 
+				Source.VersionValidFrom, 
+				Source.VersionValidTo, 
+				Source.LoadType, 
+				0, 
+				NULL, 
+				Source.Enabled)
+
+	WHEN MATCHED THEN UPDATE SET
+		Target.ComputeConnectionFK = Source.ComputeConnectionFK,
+		Target.CreateNotebookFK = Source.CreateNotebookFK,
+		Target.BusinessLogicNotebookFK = Source.BusinessLogicNotebookFK,
+		Target.VersionNumber = Source.VersionNumber,
+		Target.VersionValidFrom = Source.VersionValidFrom,
+		Target.VersionValidTo = Source.VersionValidTo,
+		Target.LoadType = Source.LoadType,
+		Target.Enabled = Source.Enabled
+	;
+END
+GO

--- a/src/metadata.transform/transform/Stored Procedures/AddNotebookTypes.sql
+++ b/src/metadata.transform/transform/Stored Procedures/AddNotebookTypes.sql
@@ -1,0 +1,27 @@
+CREATE PROCEDURE ##AddNotebookTypes
+(
+	@NotebookTypeName NVARCHAR(100),
+	@Enabled BIT
+)
+AS
+BEGIN
+	SET NOCOUNT ON;
+	WITH cte AS 
+	(
+		SELECT
+		@NotebookTypeName AS NotebookTypeName,
+		@Enabled AS Enabled
+	)
+	MERGE INTO transform.NotebookTypes AS Target
+	USING cte AS Source
+	ON Source.NotebookTypeName = Target.NotebookTypeName
+
+	WHEN NOT MATCHED THEN
+		INSERT (NotebookTypeName, Enabled) 
+		VALUES (Source.NotebookTypeName, Source.Enabled)
+
+	WHEN MATCHED THEN UPDATE SET
+		Target.Enabled			= Source.Enabled
+	;
+END
+GO

--- a/src/metadata.transform/transform/Stored Procedures/AddNotebooks.sql
+++ b/src/metadata.transform/transform/Stored Procedures/AddNotebooks.sql
@@ -1,0 +1,48 @@
+CREATE PROCEDURE ##AddNotebooks
+(
+	@NotebookTypeName NVARCHAR(100),
+	@NotebookName NVARCHAR(100),
+	@NotebookPath NVARCHAR(500),
+	@Enabled BIT
+)
+AS
+BEGIN
+	SET NOCOUNT ON;
+	DECLARE @Notebooks TABLE (
+		NotebookTypeName NVARCHAR(100),
+		NotebookTypeFK INT,
+		NotebookName NVARCHAR(100),
+		NotebookPath NVARCHAR(500),
+		Enabled BIT
+	)
+
+	INSERT INTO @Notebooks(NotebookTypeName, NotebookTypeFK, NotebookName, NotebookPath, Enabled)
+	VALUES(@NotebookTypeName, -1, @NotebookName, @NotebookPath, @Enabled)
+
+	UPDATE n
+	SET n.NotebookTypeFK = nt.NotebookTypeId
+	FROM @Notebooks AS n
+	INNER JOIN transform.NotebookTypes AS nt
+	ON n.NotebookTypeName = nt.NotebookTypeName
+
+	IF (SELECT NotebookTypeFK FROM @Notebooks) = -1
+	BEGIN
+		RAISERROR('NotebookTypeFK not updated as the NotebookTypeName does not exist within Transform.NotebookTypes.',16,1)
+		RETURN 0;
+	END
+
+	MERGE INTO transform.Notebooks AS Target
+	USING @Notebooks AS Source
+	ON Source.NotebookName = Target.NotebookName 
+	AND Source.NotebookPath = Target.NotebookPath
+
+	WHEN NOT MATCHED BY Target THEN
+		INSERT (NotebookTypeFK, NotebookName, NotebookPath, Enabled) 
+		VALUES (Source.NotebookTypeFK, Source.NotebookName, Source.NotebookPath, Source.Enabled)
+
+	WHEN MATCHED THEN UPDATE SET
+		Target.NotebookTypeFK = Source.NotebookTypeFK,
+		Target.Enabled = Source.Enabled
+	;
+END
+GO


### PR DESCRIPTION
Added all ##Add metadata stored procs to common, ingest, transform and control as well as metadataAsCode scripts including some sample data for an example database such as Adventure works. Ran tests to make sure each stored proc behaves as expected when adding new data or updating existing data.