### PR TITLE
Develop delta raw

### DIFF
--- a/src/azure.databricks/python/notebooks/ingest/ingestpayload/CheckPayloadExecution.py
+++ b/src/azure.databricks/python/notebooks/ingest/ingestpayload/CheckPayloadExecution.py
@@ -48,7 +48,7 @@ payload = json.loads(dbutils.widgets.get("Merge Payload"))
 
 # COMMAND ----------
 
-[table_name, load_type, load_action, load_action_text, version_number, raw_storage_name, raw_container_name, raw_secret, raw_last_load_date, raw_schema_name, raw_file_type, datetime_folder_hierarchy, cleansed_storage_name, cleansed_container_name, cleansed_secret, cleansed_last_load_date, cleansed_schema_name, pk_list, partition_list, columns_list, columns_type_list, columns_format_list, metadata_column_list, metadata_column_type_list, metadata_column_format_list, total_column_list, total_column_type_list, total_column_format_list] = get_merge_payload_variables(payload)
+[table_name, load_type, load_action, load_action_text, version_number, raw_storage_name, raw_container_name, raw_secret, raw_last_load_date, raw_schema_name, raw_file_type, datetime_folder_hierarchy, cleansed_storage_name, cleansed_container_name, cleansed_secret, cleansed_last_load_date, cleansed_schema_name, filter_condition, pk_list, partition_list, columns_list, columns_type_list, columns_format_list, metadata_column_list, metadata_column_type_list, metadata_column_format_list, total_column_list, total_column_type_list, total_column_format_list] = get_merge_payload_variables(payload)
 
 # COMMAND ----------
 
@@ -136,4 +136,7 @@ table_exists = check_exists_delta_table(table_path = cleansed_table_path, load_a
 
 # COMMAND ----------
 
-compare_raw_load_vs_last_cleansed_date(raw_last_load_date = raw_last_load_date,cleansed_last_load_date =cleansed_last_load_date)
+if raw_file_type == 'delta':
+    pass
+else:
+    compare_raw_load_vs_last_cleansed_date(raw_last_load_date = raw_last_load_date,cleansed_last_load_date =cleansed_last_load_date)

--- a/src/azure.databricks/python/notebooks/ingest/ingestpayload/IngestExecution.py
+++ b/src/azure.databricks/python/notebooks/ingest/ingestpayload/IngestExecution.py
@@ -61,7 +61,7 @@ pipeline_execution_datetime = pd.to_datetime(pipeline_execution_datetime, format
 
 # COMMAND ----------
 
-[table_name, load_type, load_action, load_action_text, version_number, raw_storage_name, raw_container_name, raw_secret, raw_last_load_date, raw_schema_name, raw_file_type, datetime_folder_hierarchy, cleansed_storage_name, cleansed_container_name, cleansed_secret, cleansed_last_load_date, cleansed_schema_name, pk_list, partition_list, columns_list, columns_type_list, columns_format_list, metadata_column_list, metadata_column_type_list, metadata_column_format_list, total_column_list, total_column_type_list, total_column_format_list] = get_merge_payload_variables(payload)
+[table_name, load_type, load_action, load_action_text, version_number, raw_storage_name, raw_container_name, raw_secret, raw_last_load_date, raw_schema_name, raw_file_type, datetime_folder_hierarchy, cleansed_storage_name, cleansed_container_name, cleansed_secret, cleansed_last_load_date, cleansed_schema_name, filter_condition, pk_list, partition_list, columns_list, columns_type_list, columns_format_list, metadata_column_list, metadata_column_type_list, metadata_column_format_list, total_column_list, total_column_type_list, total_column_format_list] = get_merge_payload_variables(payload)
 
 
 # COMMAND ----------
@@ -86,22 +86,30 @@ cleansed_abfss_path = set_abfss_path(cleansed_storage_name, cleansed_container_n
 # MAGIC #Get dataset from raw
 
 # COMMAND ----------
+if raw_file_type != "delta":
+    # Spark Read extended options. When switching versions of dataset, this is a required option.
+    options = {
+        'header':'True',
+        "mergeSchema": "true"
+        }
 
-# Spark Read extended options. When switching versions of dataset, this is a required option.
-options = {
-    'header':'True',
-    "mergeSchema": "true"
-    }
+    #different options for specifying, based on how we save abfss folder hierarchy.
+    file_full_path = f"{raw_abfss_path}/{raw_schema_name}/{table_name}/version={version_number}/{load_action_text}/{datetime_folder_hierarchy}/{table_name}.{raw_file_type}"
+    print(file_full_path)
 
-#different options for specifying, based on how we save abfss folder hierarchy.
-file_full_path = f"{raw_abfss_path}/{raw_schema_name}/{table_name}/version={version_number}/{load_action_text}/{datetime_folder_hierarchy}/{table_name}.{raw_file_type}"
-print(file_full_path)
-
-# assuming json,csv, parquet
-df = spark.read \
-    .options(**options) \
-    .format(raw_file_type) \
-    .load(file_full_path)
+    # assuming json,csv, parquet
+    df = spark.read \
+        .options(**options) \
+        .format(raw_file_type) \
+        .load(file_full_path)
+    
+elif raw_file_type == "delta":
+    file_full_path = f"{raw_abfss_path}/{raw_schema_name}/{table_name}"
+    df = spark.read.format("delta").load(file_full_path)
+    
+    # apply incremental loading filter
+    if load_action == "I":
+        df = spark.sql(f"SELECT * FROM {{df}} {filter_condition}",df=df)
 
 # display(df)
 

--- a/src/azure.databricks/python/notebooks/ingest/utils/ConfigurePayloadVariables.py
+++ b/src/azure.databricks/python/notebooks/ingest/utils/ConfigurePayloadVariables.py
@@ -22,6 +22,8 @@ def get_merge_payload_variables(payload: dict()) -> list():
 
     cleansed_schema_name = payload["CleansedSchemaName"] 
 
+    filter_condition = payload["FilterCondition"] 
+
     # Semantic checks for these required in the IngestChecks notebook?
     pk_list =  payload["CleansedPkList"].split(",")
     partition_list =  payload["CleansedPartitionFields"].split(",") if  payload["CleansedPartitionFields"] != "" else []
@@ -45,6 +47,6 @@ def get_merge_payload_variables(payload: dict()) -> list():
     # totalColumnTypeList = columnsTypeList
     # totalColumnFormatList = columnsFormatList
 
-    output = [table_name, load_type, load_action, load_action_text, version_number, raw_storage_name, raw_container_name, raw_secret, raw_last_load_date, raw_schema_name, raw_file_type, datetime_folder_hierarchy, cleansed_storage_name, cleansed_container_name, cleansed_secret, cleansed_last_load_date, cleansed_schema_name, pk_list, partition_list, columns_list, columns_type_list, columns_format_list, metadata_column_list, metadata_column_type_list, metadata_column_format_list, total_column_list, total_column_type_list, total_column_format_list]
+    output = [table_name, load_type, load_action, load_action_text, version_number, raw_storage_name, raw_container_name, raw_secret, raw_last_load_date, raw_schema_name, raw_file_type, datetime_folder_hierarchy, cleansed_storage_name, cleansed_container_name, cleansed_secret, cleansed_last_load_date, cleansed_schema_name, filter_condition, pk_list, partition_list, columns_list, columns_type_list, columns_format_list, metadata_column_list, metadata_column_type_list, metadata_column_format_list, total_column_list, total_column_type_list, total_column_format_list]
 
     return output

--- a/src/azure.databricks/python/tests/test_IngestConfigurePayloadVariables.py
+++ b/src/azure.databricks/python/tests/test_IngestConfigurePayloadVariables.py
@@ -40,96 +40,97 @@ def default_payload() -> dict:
         "CleansedColumnsFormatList":",",
         "CleansedPkList":"ID",
         "CleansedPartitionFields":"",
-        "DateTimeFolderHierarchy":"year=2025/month=01/day=1/hour=10"}
+        "DateTimeFolderHierarchy":"year=2025/month=01/day=1/hour=10",
+        "FilterCondition": ""}
     return payload
 
 def test_get_merge_payload_variables_table_name(default_payload):
-    [table_name, load_type, load_action, load_action_text, version_number, raw_storage_name, raw_container_name, raw_secret, raw_last_load_date, raw_schema_name, raw_file_type, datetime_folder_hierarchy, cleansed_storage_name, cleansed_container_name, cleansed_secret, cleansed_last_load_date, cleansed_schema_name, pk_list, partition_list, columns_list, columns_type_list, columns_format_list, metadata_column_list, metadata_column_type_list, metadata_column_format_list, total_column_list, total_column_type_list, total_column_format_list] = get_merge_payload_variables(payload=default_payload)
+    [table_name, load_type, load_action, load_action_text, version_number, raw_storage_name, raw_container_name, raw_secret, raw_last_load_date, raw_schema_name, raw_file_type, datetime_folder_hierarchy, cleansed_storage_name, cleansed_container_name, cleansed_secret, cleansed_last_load_date, cleansed_schema_name, filter_condition, pk_list, partition_list, columns_list, columns_type_list, columns_format_list, metadata_column_list, metadata_column_type_list, metadata_column_format_list, total_column_list, total_column_type_list, total_column_format_list] = get_merge_payload_variables(payload=default_payload)
     expected = 'testdataset'
     assert table_name == expected
 
 def test_get_merge_payload_variables_load_type_default(default_payload):
-    [table_name, load_type, load_action, load_action_text, version_number, raw_storage_name, raw_container_name, raw_secret, raw_last_load_date, raw_schema_name, raw_file_type, datetime_folder_hierarchy, cleansed_storage_name, cleansed_container_name, cleansed_secret, cleansed_last_load_date, cleansed_schema_name, pk_list, partition_list, columns_list, columns_type_list, columns_format_list, metadata_column_list, metadata_column_type_list, metadata_column_format_list, total_column_list, total_column_type_list, total_column_format_list] = get_merge_payload_variables(payload=default_payload)
+    [table_name, load_type, load_action, load_action_text, version_number, raw_storage_name, raw_container_name, raw_secret, raw_last_load_date, raw_schema_name, raw_file_type, datetime_folder_hierarchy, cleansed_storage_name, cleansed_container_name, cleansed_secret, cleansed_last_load_date, cleansed_schema_name, filter_condition, pk_list, partition_list, columns_list, columns_type_list, columns_format_list, metadata_column_list, metadata_column_type_list, metadata_column_format_list, total_column_list, total_column_type_list, total_column_format_list] = get_merge_payload_variables(payload=default_payload)
     expected = 'I'
     assert load_type == expected
 
 def test_get_merge_payload_variables_load_type_override(default_payload):
     payload = default_payload.copy()
     payload['LoadType'] = 'F'
-    [table_name, load_type, load_action, load_action_text, version_number, raw_storage_name, raw_container_name, raw_secret, raw_last_load_date, raw_schema_name, raw_file_type, datetime_folder_hierarchy, cleansed_storage_name, cleansed_container_name, cleansed_secret, cleansed_last_load_date, cleansed_schema_name, pk_list, partition_list, columns_list, columns_type_list, columns_format_list, metadata_column_list, metadata_column_type_list, metadata_column_format_list, total_column_list, total_column_type_list, total_column_format_list] = get_merge_payload_variables(payload=payload)
+    [table_name, load_type, load_action, load_action_text, version_number, raw_storage_name, raw_container_name, raw_secret, raw_last_load_date, raw_schema_name, raw_file_type, datetime_folder_hierarchy, cleansed_storage_name, cleansed_container_name, cleansed_secret, cleansed_last_load_date, cleansed_schema_name, filter_condition, pk_list, partition_list, columns_list, columns_type_list, columns_format_list, metadata_column_list, metadata_column_type_list, metadata_column_format_list, total_column_list, total_column_type_list, total_column_format_list] = get_merge_payload_variables(payload=payload)
     expected = 'F'
     assert load_type == expected
 
 def test_get_merge_payload_variables_load_action_default(default_payload):
-    [table_name, load_type, load_action, load_action_text, version_number, raw_storage_name, raw_container_name, raw_secret, raw_last_load_date, raw_schema_name, raw_file_type, datetime_folder_hierarchy, cleansed_storage_name, cleansed_container_name, cleansed_secret, cleansed_last_load_date, cleansed_schema_name, pk_list, partition_list, columns_list, columns_type_list, columns_format_list, metadata_column_list, metadata_column_type_list, metadata_column_format_list, total_column_list, total_column_type_list, total_column_format_list] = get_merge_payload_variables(payload=default_payload)
+    [table_name, load_type, load_action, load_action_text, version_number, raw_storage_name, raw_container_name, raw_secret, raw_last_load_date, raw_schema_name, raw_file_type, datetime_folder_hierarchy, cleansed_storage_name, cleansed_container_name, cleansed_secret, cleansed_last_load_date, cleansed_schema_name, filter_condition, pk_list, partition_list, columns_list, columns_type_list, columns_format_list, metadata_column_list, metadata_column_type_list, metadata_column_format_list, total_column_list, total_column_type_list, total_column_format_list] = get_merge_payload_variables(payload=default_payload)
     expected = 'F'
     assert load_action == expected
 
 def test_get_merge_payload_variables_load_action_override(default_payload):
     payload = default_payload.copy()
     payload['LoadAction'] = 'I'
-    [table_name, load_type, load_action, load_action_text, version_number, raw_storage_name, raw_container_name, raw_secret, raw_last_load_date, raw_schema_name, raw_file_type, datetime_folder_hierarchy, cleansed_storage_name, cleansed_container_name, cleansed_secret, cleansed_last_load_date, cleansed_schema_name, pk_list, partition_list, columns_list, columns_type_list, columns_format_list, metadata_column_list, metadata_column_type_list, metadata_column_format_list, total_column_list, total_column_type_list, total_column_format_list] = get_merge_payload_variables(payload=payload)
+    [table_name, load_type, load_action, load_action_text, version_number, raw_storage_name, raw_container_name, raw_secret, raw_last_load_date, raw_schema_name, raw_file_type, datetime_folder_hierarchy, cleansed_storage_name, cleansed_container_name, cleansed_secret, cleansed_last_load_date, cleansed_schema_name, filter_condition, pk_list, partition_list, columns_list, columns_type_list, columns_format_list, metadata_column_list, metadata_column_type_list, metadata_column_format_list, total_column_list, total_column_type_list, total_column_format_list] = get_merge_payload_variables(payload=payload)
     expected = 'I'
     assert load_action == expected
 
 def test_get_merge_payload_variables_load_action_text(default_payload):
-    [table_name, load_type, load_action, load_action_text, version_number, raw_storage_name, raw_container_name, raw_secret, raw_last_load_date, raw_schema_name, raw_file_type, datetime_folder_hierarchy, cleansed_storage_name, cleansed_container_name, cleansed_secret, cleansed_last_load_date, cleansed_schema_name, pk_list, partition_list, columns_list, columns_type_list, columns_format_list, metadata_column_list, metadata_column_type_list, metadata_column_format_list, total_column_list, total_column_type_list, total_column_format_list] = get_merge_payload_variables(payload=default_payload)
+    [table_name, load_type, load_action, load_action_text, version_number, raw_storage_name, raw_container_name, raw_secret, raw_last_load_date, raw_schema_name, raw_file_type, datetime_folder_hierarchy, cleansed_storage_name, cleansed_container_name, cleansed_secret, cleansed_last_load_date, cleansed_schema_name, filter_condition, pk_list, partition_list, columns_list, columns_type_list, columns_format_list, metadata_column_list, metadata_column_type_list, metadata_column_format_list, total_column_list, total_column_type_list, total_column_format_list] = get_merge_payload_variables(payload=default_payload)
     expected = 'full'
     assert load_action_text == expected
 
 def test_get_merge_payload_variables_version_number(default_payload):
-    [table_name, load_type, load_action, load_action_text, version_number, raw_storage_name, raw_container_name, raw_secret, raw_last_load_date, raw_schema_name, raw_file_type, datetime_folder_hierarchy, cleansed_storage_name, cleansed_container_name, cleansed_secret, cleansed_last_load_date, cleansed_schema_name, pk_list, partition_list, columns_list, columns_type_list, columns_format_list, metadata_column_list, metadata_column_type_list, metadata_column_format_list, total_column_list, total_column_type_list, total_column_format_list] = get_merge_payload_variables(payload=default_payload)
+    [table_name, load_type, load_action, load_action_text, version_number, raw_storage_name, raw_container_name, raw_secret, raw_last_load_date, raw_schema_name, raw_file_type, datetime_folder_hierarchy, cleansed_storage_name, cleansed_container_name, cleansed_secret, cleansed_last_load_date, cleansed_schema_name, filter_condition, pk_list, partition_list, columns_list, columns_type_list, columns_format_list, metadata_column_list, metadata_column_type_list, metadata_column_format_list, total_column_list, total_column_type_list, total_column_format_list] = get_merge_payload_variables(payload=default_payload)
     expected = '0001'
     assert version_number == expected
 
 def test_get_merge_payload_variables_version_number_tens(default_payload):
     payload = default_payload.copy()
     payload['VersionNumber'] = 10
-    [table_name, load_type, load_action, load_action_text, version_number, raw_storage_name, raw_container_name, raw_secret, raw_last_load_date, raw_schema_name, raw_file_type, datetime_folder_hierarchy, cleansed_storage_name, cleansed_container_name, cleansed_secret, cleansed_last_load_date, cleansed_schema_name, pk_list, partition_list, columns_list, columns_type_list, columns_format_list, metadata_column_list, metadata_column_type_list, metadata_column_format_list, total_column_list, total_column_type_list, total_column_format_list] = get_merge_payload_variables(payload=payload)
+    [table_name, load_type, load_action, load_action_text, version_number, raw_storage_name, raw_container_name, raw_secret, raw_last_load_date, raw_schema_name, raw_file_type, datetime_folder_hierarchy, cleansed_storage_name, cleansed_container_name, cleansed_secret, cleansed_last_load_date, cleansed_schema_name, filter_condition, pk_list, partition_list, columns_list, columns_type_list, columns_format_list, metadata_column_list, metadata_column_type_list, metadata_column_format_list, total_column_list, total_column_type_list, total_column_format_list] = get_merge_payload_variables(payload=payload)
     expected = '0010'
     assert version_number == expected
 
 def test_get_merge_payload_variables_version_number_hundreds(default_payload):
     payload = default_payload.copy()
     payload['VersionNumber'] = 151
-    [table_name, load_type, load_action, load_action_text, version_number, raw_storage_name, raw_container_name, raw_secret, raw_last_load_date, raw_schema_name, raw_file_type, datetime_folder_hierarchy, cleansed_storage_name, cleansed_container_name, cleansed_secret, cleansed_last_load_date, cleansed_schema_name, pk_list, partition_list, columns_list, columns_type_list, columns_format_list, metadata_column_list, metadata_column_type_list, metadata_column_format_list, total_column_list, total_column_type_list, total_column_format_list] = get_merge_payload_variables(payload=payload)
+    [table_name, load_type, load_action, load_action_text, version_number, raw_storage_name, raw_container_name, raw_secret, raw_last_load_date, raw_schema_name, raw_file_type, datetime_folder_hierarchy, cleansed_storage_name, cleansed_container_name, cleansed_secret, cleansed_last_load_date, cleansed_schema_name, filter_condition, pk_list, partition_list, columns_list, columns_type_list, columns_format_list, metadata_column_list, metadata_column_type_list, metadata_column_format_list, total_column_list, total_column_type_list, total_column_format_list] = get_merge_payload_variables(payload=payload)
     expected = '0151'
     assert version_number == expected
 
 def test_get_merge_payload_variables_pk_list_empty(default_payload):
     payload = default_payload.copy()
     payload['CleansedPkList'] = ""
-    [table_name, load_type, load_action, load_action_text, version_number, raw_storage_name, raw_container_name, raw_secret, raw_last_load_date, raw_schema_name, raw_file_type, datetime_folder_hierarchy, cleansed_storage_name, cleansed_container_name, cleansed_secret, cleansed_last_load_date, cleansed_schema_name, pk_list, partition_list, columns_list, columns_type_list, columns_format_list, metadata_column_list, metadata_column_type_list, metadata_column_format_list, total_column_list, total_column_type_list, total_column_format_list] = get_merge_payload_variables(payload=payload)
+    [table_name, load_type, load_action, load_action_text, version_number, raw_storage_name, raw_container_name, raw_secret, raw_last_load_date, raw_schema_name, raw_file_type, datetime_folder_hierarchy, cleansed_storage_name, cleansed_container_name, cleansed_secret, cleansed_last_load_date, cleansed_schema_name, filter_condition, pk_list, partition_list, columns_list, columns_type_list, columns_format_list, metadata_column_list, metadata_column_type_list, metadata_column_format_list, total_column_list, total_column_type_list, total_column_format_list] = get_merge_payload_variables(payload=payload)
     expected = ['']
     assert pk_list == expected
 
 def test_get_merge_payload_variables_pk_list_single(default_payload):
-    [table_name, load_type, load_action, load_action_text, version_number, raw_storage_name, raw_container_name, raw_secret, raw_last_load_date, raw_schema_name, raw_file_type, datetime_folder_hierarchy, cleansed_storage_name, cleansed_container_name, cleansed_secret, cleansed_last_load_date, cleansed_schema_name, pk_list, partition_list, columns_list, columns_type_list, columns_format_list, metadata_column_list, metadata_column_type_list, metadata_column_format_list, total_column_list, total_column_type_list, total_column_format_list] = get_merge_payload_variables(payload=default_payload)
+    [table_name, load_type, load_action, load_action_text, version_number, raw_storage_name, raw_container_name, raw_secret, raw_last_load_date, raw_schema_name, raw_file_type, datetime_folder_hierarchy, cleansed_storage_name, cleansed_container_name, cleansed_secret, cleansed_last_load_date, cleansed_schema_name, filter_condition, pk_list, partition_list, columns_list, columns_type_list, columns_format_list, metadata_column_list, metadata_column_type_list, metadata_column_format_list, total_column_list, total_column_type_list, total_column_format_list] = get_merge_payload_variables(payload=default_payload)
     expected = ['ID']
     assert pk_list == expected
 
 def test_get_merge_payload_variables_pk_list_multiple(default_payload):
     payload = default_payload.copy()
     payload['CleansedPkList'] = "ID,NAME"
-    [table_name, load_type, load_action, load_action_text, version_number, raw_storage_name, raw_container_name, raw_secret, raw_last_load_date, raw_schema_name, raw_file_type, datetime_folder_hierarchy, cleansed_storage_name, cleansed_container_name, cleansed_secret, cleansed_last_load_date, cleansed_schema_name, pk_list, partition_list, columns_list, columns_type_list, columns_format_list, metadata_column_list, metadata_column_type_list, metadata_column_format_list, total_column_list, total_column_type_list, total_column_format_list] = get_merge_payload_variables(payload=payload)
+    [table_name, load_type, load_action, load_action_text, version_number, raw_storage_name, raw_container_name, raw_secret, raw_last_load_date, raw_schema_name, raw_file_type, datetime_folder_hierarchy, cleansed_storage_name, cleansed_container_name, cleansed_secret, cleansed_last_load_date, cleansed_schema_name, filter_condition, pk_list, partition_list, columns_list, columns_type_list, columns_format_list, metadata_column_list, metadata_column_type_list, metadata_column_format_list, total_column_list, total_column_type_list, total_column_format_list] = get_merge_payload_variables(payload=payload)
     expected = ["ID","NAME"]
     assert pk_list == expected
 
 def test_get_merge_payload_variables_partition_list_empty(default_payload):
-    [table_name, load_type, load_action, load_action_text, version_number, raw_storage_name, raw_container_name, raw_secret, raw_last_load_date, raw_schema_name, raw_file_type, datetime_folder_hierarchy, cleansed_storage_name, cleansed_container_name, cleansed_secret, cleansed_last_load_date, cleansed_schema_name, pk_list, partition_list, columns_list, columns_type_list, columns_format_list, metadata_column_list, metadata_column_type_list, metadata_column_format_list, total_column_list, total_column_type_list, total_column_format_list] = get_merge_payload_variables(payload=default_payload)
+    [table_name, load_type, load_action, load_action_text, version_number, raw_storage_name, raw_container_name, raw_secret, raw_last_load_date, raw_schema_name, raw_file_type, datetime_folder_hierarchy, cleansed_storage_name, cleansed_container_name, cleansed_secret, cleansed_last_load_date, cleansed_schema_name, filter_condition, pk_list, partition_list, columns_list, columns_type_list, columns_format_list, metadata_column_list, metadata_column_type_list, metadata_column_format_list, total_column_list, total_column_type_list, total_column_format_list] = get_merge_payload_variables(payload=default_payload)
     expected = []
     assert partition_list == expected
 
 def test_get_merge_payload_variables_partition_list_single(default_payload):
     payload = default_payload.copy()
     payload['CleansedPartitionFields'] = "ID"
-    [table_name, load_type, load_action, load_action_text, version_number, raw_storage_name, raw_container_name, raw_secret, raw_last_load_date, raw_schema_name, raw_file_type, datetime_folder_hierarchy, cleansed_storage_name, cleansed_container_name, cleansed_secret, cleansed_last_load_date, cleansed_schema_name, pk_list, partition_list, columns_list, columns_type_list, columns_format_list, metadata_column_list, metadata_column_type_list, metadata_column_format_list, total_column_list, total_column_type_list, total_column_format_list] = get_merge_payload_variables(payload=payload)
+    [table_name, load_type, load_action, load_action_text, version_number, raw_storage_name, raw_container_name, raw_secret, raw_last_load_date, raw_schema_name, raw_file_type, datetime_folder_hierarchy, cleansed_storage_name, cleansed_container_name, cleansed_secret, cleansed_last_load_date, cleansed_schema_name, filter_condition, pk_list, partition_list, columns_list, columns_type_list, columns_format_list, metadata_column_list, metadata_column_type_list, metadata_column_format_list, total_column_list, total_column_type_list, total_column_format_list] = get_merge_payload_variables(payload=payload)
     expected = ["ID"]
     assert partition_list == expected
 
 def test_get_merge_payload_variables_partition_list_multiple(default_payload):
     payload = default_payload.copy()
     payload['CleansedPartitionFields'] = "ID,NAME"
-    [table_name, load_type, load_action, load_action_text, version_number, raw_storage_name, raw_container_name, raw_secret, raw_last_load_date, raw_schema_name, raw_file_type, datetime_folder_hierarchy, cleansed_storage_name, cleansed_container_name, cleansed_secret, cleansed_last_load_date, cleansed_schema_name, pk_list, partition_list, columns_list, columns_type_list, columns_format_list, metadata_column_list, metadata_column_type_list, metadata_column_format_list, total_column_list, total_column_type_list, total_column_format_list] = get_merge_payload_variables(payload=payload)
+    [table_name, load_type, load_action, load_action_text, version_number, raw_storage_name, raw_container_name, raw_secret, raw_last_load_date, raw_schema_name, raw_file_type, datetime_folder_hierarchy, cleansed_storage_name, cleansed_container_name, cleansed_secret, cleansed_last_load_date, cleansed_schema_name, filter_condition, pk_list, partition_list, columns_list, columns_type_list, columns_format_list, metadata_column_list, metadata_column_type_list, metadata_column_format_list, total_column_list, total_column_type_list, total_column_format_list] = get_merge_payload_variables(payload=payload)
     expected = ["ID","NAME"]
     assert partition_list == expected

--- a/src/metadata.ingest/ingest/Functions/GetIngestLoadAction.sql
+++ b/src/metadata.ingest/ingest/Functions/GetIngestLoadAction.sql
@@ -11,6 +11,7 @@ CREATE FUNCTION [ingest].[GetIngestLoadAction]
     DECLARE @LoadAction VARCHAR(1)
     DECLARE @RawLastLoadDate DATETIME2
     DECLARE @CleansedLastLoadDate DATETIME2
+    DECLARE @ExtensionType NVARCHAR(20)
 
     -- Defensive check for valid @IngestStage parameter: RAISERROR not allowed in UDF
     -- IF @IngestStage NOT IN ('Raw','Cleansed')
@@ -20,12 +21,14 @@ CREATE FUNCTION [ingest].[GetIngestLoadAction]
 
     SELECT 
         @LoadStatus = LoadStatus,
-        @LoadType = LoadType
+        @LoadType = LoadType,
+        @ExtensionType = ExtensionType
     FROM 
         ingest.[Datasets]
     WHERE
         DatasetId = @DatasetId
 
+    -- U = Unpack, used for Excel data sources. Therefore, always perform a full load.
     IF @LoadType = 'U'
     BEGIN
         SET @LoadType = 'F'
@@ -35,32 +38,43 @@ CREATE FUNCTION [ingest].[GetIngestLoadAction]
 
     -- No load of any kind for this dataset
     -- next raw load: full
-    -- next incremental load: error
+    -- next incremental load (if bronze type <> Delta): error
+    -- next incremental load (if bronze type = Delta): full
     IF @LoadStatus = 0 
     BEGIN
         IF @IngestStage = 'Raw'
         BEGIN
             SET @LoadAction = 'F'
         END
-        IF @IngestStage = 'Cleansed'
+        IF @IngestStage = 'Cleansed' AND @ExtensionType <> 'Delta'
         BEGIN
             SET @LoadAction = 'X'
             --RAISERROR('No Raw Full load completed. Please confirm this has not failed before proceeding with this cleansed load operation.',16,1)
         END
+        IF @IngestStage = 'Cleansed' AND @ExtensionType = 'Delta'
+        BEGIN
+            SET @LoadAction = 'F'
+        END
     END
+
     -- raw no loads
     -- next raw load: full
-    -- next incremental load: error
+    -- next incremental load (if bronze type <> Delta): error
+    -- next incremental load (if bronze type = Delta): full
     IF ( (2 & @LoadStatus) <> 2 )
     BEGIN
         IF @IngestStage = 'Raw'
         BEGIN
             SET @LoadAction = 'F'
         END
-        IF @IngestStage = 'Cleansed'
+        IF @IngestStage = 'Cleansed' AND @ExtensionType <> 'Delta'
         BEGIN
             SET @LoadAction = 'X'
             -- RAISERROR('No Raw Full load completed. Please confirm this has not failed before proceeding with this cleansed load operation.',16,1)
+        END
+        IF @IngestStage = 'Cleansed' AND @ExtensionType = 'Delta'
+        BEGIN
+            SET @LoadAction = 'F'
         END
     END
 

--- a/src/metadata.ingest/ingest/Functions/GetIngestLoadAction.sql
+++ b/src/metadata.ingest/ingest/Functions/GetIngestLoadAction.sql
@@ -34,47 +34,43 @@ CREATE FUNCTION [ingest].[GetIngestLoadAction]
         SET @LoadType = 'F'
     END
 
+    -- If Bronze is a delta table, register a load status that reflects that a full and incremental load into raw has been performed. This ensures the Merge to cleansed performs as able.
+    IF @ExtensionType = 'Delta'
+    BEGIN
+        SET @LoadStatus = @LoadStatus | POWER(2,1) | POWER(2,2) 
+    END
+    
     -- PRINT @LoadStatus
 
     -- No load of any kind for this dataset
     -- next raw load: full
-    -- next incremental load (if bronze type <> Delta): error
-    -- next incremental load (if bronze type = Delta): full
+    -- next incremental load: error
     IF @LoadStatus = 0 
     BEGIN
         IF @IngestStage = 'Raw'
         BEGIN
             SET @LoadAction = 'F'
         END
-        IF @IngestStage = 'Cleansed' AND @ExtensionType <> 'Delta'
+        IF @IngestStage = 'Cleansed'
         BEGIN
             SET @LoadAction = 'X'
             --RAISERROR('No Raw Full load completed. Please confirm this has not failed before proceeding with this cleansed load operation.',16,1)
-        END
-        IF @IngestStage = 'Cleansed' AND @ExtensionType = 'Delta'
-        BEGIN
-            SET @LoadAction = 'F'
         END
     END
 
     -- raw no loads
     -- next raw load: full
-    -- next incremental load (if bronze type <> Delta): error
-    -- next incremental load (if bronze type = Delta): full
+    -- next incremental load: error
     IF ( (2 & @LoadStatus) <> 2 )
     BEGIN
         IF @IngestStage = 'Raw'
         BEGIN
             SET @LoadAction = 'F'
         END
-        IF @IngestStage = 'Cleansed' AND @ExtensionType <> 'Delta'
+        IF @IngestStage = 'Cleansed'
         BEGIN
             SET @LoadAction = 'X'
             -- RAISERROR('No Raw Full load completed. Please confirm this has not failed before proceeding with this cleansed load operation.',16,1)
-        END
-        IF @IngestStage = 'Cleansed' AND @ExtensionType = 'Delta'
-        BEGIN
-            SET @LoadAction = 'F'
         END
     END
 

--- a/src/metadata.ingest/ingest/Stored Procedures/AddDatasets.sql
+++ b/src/metadata.ingest/ingest/Stored Procedures/AddDatasets.sql
@@ -4,6 +4,10 @@ CREATE PROCEDURE [ingest].[AddDatasets]
 	@LinkedServiceName NVARCHAR(200),
 	@ResourceName NVARCHAR(100),
 	@ComputeConnectionDisplayName NVARCHAR(50),
+	@RawConnectionDisplayName NVARCHAR(50),
+	@RawSourceLocation  NVARCHAR(200),
+	@CleansedConnectionDisplayName NVARCHAR(50),
+	@CleansedSourceLocation  NVARCHAR(200),
 	@DatasetDisplayName NVARCHAR(50),
 	@SourcePath NVARCHAR(100),
 	@SourceName NVARCHAR(100),
@@ -30,6 +34,12 @@ BEGIN
 		ResourceName NVARCHAR(100),
 		MergeComputeConnectionFK INT,
 		ComputeConnectionDisplayName NVARCHAR(50),
+		RawStorageConnectionFK INT,
+		RawConnectionDisplayName NVARCHAR(50),
+		RawSourceLocation NVARCHAR(200),
+		CleansedStorageConnectionFK INT,
+		CleansedConnectionDisplayName NVARCHAR(50),
+		CleansedSourceLocation  NVARCHAR(200),
 		DatasetDisplayName NVARCHAR(50) NOT NULL,
 		SourcePath NVARCHAR(100) NOT NULL,
 		SourceName NVARCHAR(100)NOT NULL,
@@ -47,9 +57,11 @@ BEGIN
 	)
 
 	INSERT INTO @Datasets(ConnectionFK, ConnectionDisplayName, LinkedServiceName, ResourceName, MergeComputeConnectionFK, ComputeConnectionDisplayName, 
+						RawStorageConnectionFK, RawConnectionDisplayName,RawSourceLocation,CleansedStorageConnectionFK, CleansedConnectionDisplayName,CleansedSourceLocation,
 						DatasetDisplayName, SourcePath, SourceName, ExtensionType, VersionNumber, VersionValidFrom, VersionValidTo, 
 						LoadType, LoadStatus, OverrideLoadStatus, LoadClause, CleansedPath, CleansedName, Enabled)
-	VALUES (-1, @ConnectionDisplayName, @LinkedServiceName, @ResourceName, -1, @ComputeConnectionDisplayName, @DatasetDisplayName, @SourcePath, @SourceName, 
+	VALUES (-1, @ConnectionDisplayName, @LinkedServiceName, @ResourceName, -1, @ComputeConnectionDisplayName, -1, @RawConnectionDisplayName, @RawSourceLocation, 
+			-1, @CleansedConnectionDisplayName,@CleansedSourceLocation, @DatasetDisplayName, @SourcePath, @SourceName, 
 			@ExtensionType, @VersionNumber, @VersionValidFrom, @VersionValidTo, @LoadType, @LoadStatus, @OverrideLoadStatus, @LoadClause, 
 			@CleansedPath, @CleansedName, @Enabled)
 
@@ -61,6 +73,7 @@ BEGIN
 	AND c.LinkedServiceName = d.LinkedServiceName
 	AND c.ResourceName = d.ResourceName
 
+	-- Validate ConnectionFK is successfully updated
 	IF (SELECT ConnectionFK FROM @Datasets) = -1
 	BEGIN
 		RAISERROR('ConnectionFK not updated as the ConnectionDisplayName / LinkedServiceName combination of values does not exist within common.ConnectionTypes.',16,1)
@@ -73,10 +86,38 @@ BEGIN
 	INNER JOIN common.ComputeConnections AS c
 	ON c.ConnectionDisplayName = d.ComputeConnectionDisplayName
 
-
+	-- Validate the MergeComputeConnectionFK is successfully updated
 	IF (SELECT MergeComputeConnectionFK FROM @Datasets) = -1
 	BEGIN
 		RAISERROR('MergeComputeConnectionFK not updated as the ComputeConnectionTypeDisplayName does not exist within common.ComputeConnections.',16,1)
+		RETURN 0;
+	END
+
+	UPDATE d
+	SET d.RawStorageConnectionFK = c.ConnectionId
+	FROM @Datasets AS d
+	INNER JOIN common.Connections AS c
+	ON c.ConnectionDisplayName = d.RawConnectionDisplayName
+	AND c.SourceLocation = d.RawSourceLocation
+
+	-- Validate the RawStorage Connection FK is successfully updated
+	IF (SELECT RawStorageConnectionFK FROM @Datasets) = -1
+	BEGIN
+		RAISERROR('RawStorageConnectionFK not updated as a record for the RawConnectionDisplayName and RawStorageLocation values does not exist within common.Connections.',16,1)
+		RETURN 0;
+	END
+
+	UPDATE d
+	SET d.CleansedStorageConnectionFK = c.ConnectionId
+	FROM @Datasets AS d
+	INNER JOIN common.Connections AS c
+	ON c.ConnectionDisplayName = d.CleansedConnectionDisplayName
+	AND c.SourceLocation = d.CleansedSourceLocation
+
+	-- Validate the CleansedStorage Connection FK is successfully updated
+	IF (SELECT CleansedStorageConnectionFK FROM @Datasets) = -1
+	BEGIN
+		RAISERROR('CleansedStorageConnectionFK not updated as a record for the CleansedConnectionDisplayName and CleansedStorageLocation values does not exist within common.Connections.',16,1)
 		RETURN 0;
 	END
 
@@ -89,6 +130,8 @@ BEGIN
 	WHEN NOT MATCHED THEN
 		INSERT (ConnectionFK, 
 				MergeComputeConnectionFK, 
+				RawStorageConnectionFK,
+				CleansedStorageConnectionFK,
 				DatasetDisplayName, 
 				SourcePath, 
 				SourceName, 
@@ -108,6 +151,8 @@ BEGIN
 				Enabled)
 		VALUES (Source.ConnectionFK, 
 				Source.MergeComputeConnectionFK, 
+				Source.RawStorageConnectionFK,
+				Source.CleansedStorageConnectionFK,
 				Source.DatasetDisplayName, 
 				Source.SourcePath, 
 				Source.SourceName, 
@@ -128,6 +173,8 @@ BEGIN
 
 	WHEN MATCHED THEN UPDATE SET
 		Target.MergeComputeConnectionFK = Source.MergeComputeConnectionFK,
+		Target.RawStorageConnectionFK = Source.RawStorageConnectionFK,
+		Target.CleansedStorageConnectionFK = Source.CleansedStorageConnectionFK,
 		Target.SourcePath = Source.SourcePath,
 		Target.SourceName = Source.SourceName,
 		Target.ExtensionType = Source.ExtensionType,

--- a/src/metadata.ingest/ingest/Stored Procedures/GetDatasetPayload.sql
+++ b/src/metadata.ingest/ingest/Stored Procedures/GetDatasetPayload.sql
@@ -15,7 +15,7 @@ BEGIN
     INNER JOIN [common].[Connections] cn1
         ON ds.[ConnectionFK] = cn1.[ConnectionId]
     INNER JOIN [common].[Connections] cn2
-        ON cn2.[ConnectionDisplayName] = 'PrimaryDataLake' AND cn2.[SourceLocation] IN ('raw','bronze')
+        ON ds.[RawStorageConnectionFK] = cn2.ConnectionId AND cn2.[SourceLocation] IN ('raw','bronze')
     INNER JOIN [common].[Connections] cn3
         ON cn3.[ConnectionDisplayName] = 'PrimaryKeyVault'
     WHERE
@@ -414,7 +414,7 @@ BEGIN
     INNER JOIN [common].[Connections] cn1
     ON ds.[ConnectionFK] = cn1.[ConnectionId]
     INNER JOIN [common].[Connections] cn2
-    ON cn2.[ConnectionDisplayName] = 'PrimaryDataLake' AND cn2.[SourceLocation] IN ('raw','bronze')
+    ON ds.[RawStorageConnectionFK] = cn2.ConnectionId AND cn2.[SourceLocation] IN ('raw','bronze')
     INNER JOIN [common].[Connections] cn3
     ON cn3.[ConnectionDisplayName] = 'PrimaryKeyVault'
     WHERE

--- a/src/metadata.ingest/ingest/Stored Procedures/GetMergePayload.sql
+++ b/src/metadata.ingest/ingest/Stored Procedures/GetMergePayload.sql
@@ -61,6 +61,18 @@ BEGIN
         RETURN 0;
     END
 
+    DECLARE @FilterCondition NVARCHAR(MAX)
+
+    SELECT 
+        @FilterCondition = 
+        CASE 
+            WHEN ExtensionType = 'Delta' THEN LoadClause
+            ELSE ''
+        END
+    FROM
+        [ingest].[Datasets]
+    WHERE
+        DatasetId = @DatasetId
 
     DECLARE @CleansedColumnsList NVARCHAR(MAX)
     DECLARE @CleansedColumnsTypeList NVARCHAR(MAX)
@@ -216,7 +228,8 @@ BEGIN
         @CleansedColumnsFormatList AS 'CleansedColumnsFormatList',
         @PkAttributesList AS 'CleansedPkList',
         @PartitionByAttributesList AS 'CleansedPartitionFields',
-        @DateTimeFolderHierarchy AS 'DateTimeFolderHierarchy'
+        @DateTimeFolderHierarchy AS 'DateTimeFolderHierarchy',
+        @FilterCondition AS 'FilterCondition'
     FROM 
         [ingest].[Datasets] AS ds
     INNER JOIN 

--- a/src/metadata.ingest/ingest/Stored Procedures/GetMergePayload.sql
+++ b/src/metadata.ingest/ingest/Stored Procedures/GetMergePayload.sql
@@ -32,11 +32,11 @@ BEGIN
     INNER JOIN
         [common].Connections AS cn5
     ON 
-        cn5.ConnectionDisplayName = 'PrimaryDataLake' AND cn5.SourceLocation IN ('raw','bronze')
+        ds.RawStorageConnectionFK = cn5.ConnectionId AND cn5.SourceLocation IN ('raw','bronze')
     INNER JOIN
         [common].Connections AS cn6
     ON 
-        cn6.ConnectionDisplayName = 'PrimaryDataLake' AND cn6.SourceLocation IN ('cleansed', 'silver')
+        ds.CleansedStorageConnectionFK = cn6.ConnectionId AND cn6.SourceLocation IN ('cleansed', 'silver')
 
     WHERE
         ds.DatasetId = @DatasetId
@@ -251,11 +251,11 @@ BEGIN
     INNER JOIN
         [common].Connections AS cn5
     ON 
-        cn5.ConnectionDisplayName = 'PrimaryDataLake' AND cn5.SourceLocation IN ('raw','bronze')
+        ds.RawStorageConnectionFK = cn5.ConnectionId AND cn5.SourceLocation IN ('raw','bronze')
     INNER JOIN
         [common].Connections AS cn6
     ON 
-        cn6.ConnectionDisplayName = 'PrimaryDataLake' AND cn6.SourceLocation IN ('cleansed','silver')
+        ds.CleansedStorageConnectionFK = cn6.ConnectionId AND cn6.SourceLocation IN ('cleansed', 'silver')
     INNER JOIN 
         [common].Connections AS cn7
     ON cn7.ConnectionDisplayName = 'PrimaryKeyVault'

--- a/src/metadata.ingest/ingest/Tables/Datasets.sql
+++ b/src/metadata.ingest/ingest/Tables/Datasets.sql
@@ -2,6 +2,8 @@ CREATE TABLE [ingest].[Datasets](
 	[DatasetId] [int] IDENTITY(1,1) NOT NULL,
 	[ConnectionFK] [int] NOT NULL,
 	[MergeComputeConnectionFK] [int] NULL,
+	[RawStorageConnectionFK] INT NOT NULL,
+	[CleansedStorageConnectionFK] INT NOT NULL,
 	[DatasetDisplayName] [nvarchar](50) NOT NULL,
 	[SourcePath] [nvarchar](100) NOT NULL,
 	[SourceName] [nvarchar](100) NOT NULL,


### PR DESCRIPTION
Add support for pre-created Delta tables within the "raw" layer. 
This includes full and incremental loads from this source.
Additional support for "non-primary" storage accounts, improving Databricks' ability to read from and save to different ADLS accounts and containers. 